### PR TITLE
Move some classes from rapid-vulkan.h to rapid-vulkan.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ int main() {
 This is the simplist form of an app created out of the rapid-vulkan library. It creates a Vulkan instance using default options. Then creates a Vulkan device out of that instance.
 
 # Pipeline
-VkPipeline sits at the center of Vulkan architecture that defines how GPU pipeline should be configured to render the scene. It is powerful but tediours to use. You'll have to create and manage an whole series of supporting objects, such as pipeline layout, descriptor set layout, descriptor set, descriptor pool to use it. To simplify this task, the rapid-vulkan library wraps all of them into 3 easy to use classes: **Pipeline**, **PipelineLayout** and **ArgumentPack**
+VkPipeline sits at the center of Vulkan architecture that defines how GPU pipeline should be configured to render the scene. It is powerful but tediours to use. You'll have to create and manage an whole series of supporting objects, such as pipeline layout, descriptor set layout, descriptor set, descriptor pool to use it. To simplify this task, the rapid-vulkan library wraps all of them into 2 easy to use classes: **Pipeline** and **ArgumentPack**
 
 Before going into details, here is an example of using these 3 classes to issue a draw command:
 
@@ -82,12 +82,11 @@ Before going into details, here is an example of using these 3 classes to issue 
     auto vs  = Shader(...);
     auto fs  = Shader(...);
     auto gcp = GraphicsPipeline::ConstructParameters {}.setRenderPass(rp).setVS(&vs).setFS(&fs);
-    // TODO: set more pipeline parameters here.
+    // set more pipeline parameters here.
     auto p = GraphicsPipeline(gcp);
-
 ```
 
-**Pipeline** class is basically a wrapper of VkPipeline object. It has 2 sub classes for compute and graphcis pipeline. It has some utility methods that makes constructing a pipeline object a bit less verbose.
+**Pipeline** class is basically a wrapper of VkPipeline object. It has 2 sub classes for compute and graphcis pipeline. It comes with utility methods that makes constructing a pipeline object more intuitive. Similar as the native vk::Pipeline handle, once constructured. It is immutable.
 
 **PipelineLayout**
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This is the simplist form of an app created out of the rapid-vulkan library. It 
 # Pipeline
 VkPipeline sits at the center of Vulkan architecture that defines how GPU pipeline should be configured to render the scene. It is powerful but tediours to use. You'll have to create and manage an whole series of supporting objects, such as pipeline layout, descriptor set layout, descriptor set, descriptor pool to use it. To simplify this task, the rapid-vulkan library wraps all of them into 2 easy to use classes: **Pipeline** and **ArgumentPack**
 
-Here is an example of using these classes to issue a draw command:
+Here is an simplified example of using these classes to issue a draw command. See [pipeline-args](dev/sample/pipeline-args.cpp) for full source code.
 
 ```c++
     GlobalInfo     gi = getVulkanGlobalInfo(...); // get vulkan global information, usually from a Device object.

--- a/README.md
+++ b/README.md
@@ -75,20 +75,36 @@ This is the simplist form of an app created out of the rapid-vulkan library. It 
 # Pipeline
 VkPipeline sits at the center of Vulkan architecture that defines how GPU pipeline should be configured to render the scene. It is powerful but tediours to use. You'll have to create and manage an whole series of supporting objects, such as pipeline layout, descriptor set layout, descriptor set, descriptor pool to use it. To simplify this task, the rapid-vulkan library wraps all of them into 2 easy to use classes: **Pipeline** and **ArgumentPack**
 
-Before going into details, here is an example of using these 3 classes to issue a draw command:
+Here is an example of using these classes to issue a draw command:
 
 ```c++
-    auto rp  = getYourRenderPass(...);
-    auto vs  = Shader(...);
-    auto fs  = Shader(...);
-    auto gcp = GraphicsPipeline::ConstructParameters {}.setRenderPass(rp).setVS(&vs).setFS(&fs);
-    // set more pipeline parameters here.
+    GlobalInfo     gi = getVulkanGlobalInfo(...); // get vulkan global information, usually from a Device object.
+    vk::RenderPass rp = getYourRenderPass(...); // get a render pass, usually from a Swapchian class.
+    Shader         vs(...); // construct your vertex shader
+    Shader         fs(...); // construct your fragment shader.
+
+    // Config the pipeline via the construction parameters
+    GraphicsPipeline::ConstructParameters gcp {"my pipeline", gi};
+    gcp.set.setRenderPass(rp).setVS(&vs).setFS(&fs);
+
+    // create the pipeline object
     auto p = GraphicsPipeline(gcp);
+
+    // create argument pack
+    auto args = ArgumentPack({"name"});
+    args.b({0, 0}, {buffer1}); // bind buffer 1 to set 0, binding 0
+    args.i({1, 2}, {image1, image2}); // bind image1 and image2 to set 0, binding 2
+
+    // issue the draw
+    ...
+    p.cmdBind(commandBuffer, args);
+    p.draw(commandBufer, ...);
+    ...
 ```
 
-**Pipeline** class is basically a wrapper of VkPipeline object. It has 2 sub classes for compute and graphcis pipeline. It comes with utility methods that makes constructing a pipeline object more intuitive. Similar as the native vk::Pipeline handle, once constructured. It is immutable.
+**Pipeline** class is basically a wrapper of VkPipeline object. It has 2 sub classes for compute and graphcis pipeline. It comes with utility methods that makes constructing a pipeline object more intuitive. Similar as the native vk::Pipeline handle, it is **immutable** once constructured.
 
-**PipelineLayout**
+**ArgumentPack** class stores the data used for rendering, such as buffer, image and constants. It is basically a map from resource location (set and binding), to resource handles. Note that Vulkan allows an array of resource of same type to be bound to a single bind location. This is why the second parameter of method `b()` and `i()` is an array.
 
 # License
 The library is released under MIT license. See [LICENSE](LICENSE) file for details.

--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -1,8 +1,11 @@
 # P0
-- Push constant support in pipeline and argument pack
-- Sample:
-  - rotating triangle with uniform value updated once every frame.
-= Pipeline and layout cache
+- A Drawable class that contains a pipline and resources (buffers, images, constants) used by the pipeline.
+- A 3D model viewer that as a complex-enough use case of the library.
+
+# P1
+- A more powerful render pass class that combined vk::RenderPass and vk::Framebuffers together.
+  - this is not a P0 task, since Swapchain's built-in render pass can handle the most common usages already.
+- Pipeline and layout cache
 
 # Resource/Descriptor Design Choices
 

--- a/dev/sample/pipeline-args.cpp
+++ b/dev/sample/pipeline-args.cpp
@@ -90,7 +90,7 @@ void entry(const Options & options) {
         u1.setContent(bc.setData<float>({(float) std::sin(elapsed) * .5f + .5f, (float) std::cos(elapsed) * .5f + .5f, 1.f}));
 
         // begin the render pass
-        sw.cmdBeginBuiltInRenderPass(c, Swapchain::BeginRenderPassParameters {}.setColorF(0.0f, 1.0f, 0.0f, 1.0f)); // clear to green
+        sw.cmdBeginBuiltInRenderPass(c, Swapchain::BeginRenderPassParameters {}.setClearColorF({0.0f, 1.0f, 0.0f, 1.0f})); // clear to green
 
         // bind the arguments to the pipeline
         p.cmdBind(c, args);

--- a/dev/sample/simple-triangle.cpp
+++ b/dev/sample/simple-triangle.cpp
@@ -71,8 +71,8 @@ void entry(const Options & options) {
         }
         auto & frame = sw.currentFrame();
         auto   c     = q.begin("simple-triangle");
-        sw.cmdBeginBuiltInRenderPass(c, Swapchain::BeginRenderPassParameters {}.setColorF(0.0f, 1.0f, 0.0f, 1.0f)); // clear to green
-        p.cmdDraw(c, GraphicsPipeline::DrawParameters {}.setNonIndexed(3));                                         // then draw a blue triangle.
+        sw.cmdBeginBuiltInRenderPass(c, Swapchain::BeginRenderPassParameters {}.setClearColorF({0.0f, 1.0f, 0.0f, 1.0f})); // clear to green
+        p.cmdDraw(c, GraphicsPipeline::DrawParameters {}.setNonIndexed(3));                                                // then draw a blue triangle.
         sw.cmdEndBuiltInRenderPass(c);
         q.submit({c, {}, {frame.imageAvailable}, {frame.renderFinished}});
         sw.present({});

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -1385,56 +1385,6 @@ private:
 };
 
 // ---------------------------------------------------------------------------------------------------------------------
-/// VkFramebuffer wrapper class
-class Framebuffer : public Root {
-public:
-    struct ConstructParameters : public Root::ConstructParameters {
-        const GlobalInfo *         gi   = nullptr;
-        vk::RenderPass             pass = {};
-        std::vector<vk::ImageView> attachments {};
-        size_t                     width  = 1;
-        size_t                     height = 1;
-        size_t                     layers = 1;
-
-        ConstructParameters & setRenderPass(vk::RenderPass v) {
-            pass = v;
-            return *this;
-        }
-
-        ConstructParameters & addImage(Image & image);
-
-        ConstructParameters & addImageView(vk::ImageView view) {
-            attachments.emplace_back(view);
-            return *this;
-        }
-
-        ConstructParameters & setExtent(size_t w, size_t h, size_t l = 1) {
-            width  = w;
-            height = h;
-            layers = l;
-            return *this;
-        }
-    };
-
-    Framebuffer(const ConstructParameters &);
-
-    ~Framebuffer();
-
-    vk::Framebuffer handle() const { return _handle; }
-
-    operator vk::Framebuffer() const { return _handle; }
-
-    operator VkFramebuffer() const { return _handle; }
-
-protected:
-    void onNameChanged(const std::string &) override;
-
-private:
-    const GlobalInfo * _gi     = nullptr;
-    vk::Framebuffer    _handle = {};
-};
-
-// ---------------------------------------------------------------------------------------------------------------------
 /// @brief View to a sub-range of a buffer.
 struct BufferView {
     vk::Buffer     buffer = {};
@@ -1887,7 +1837,7 @@ public:
     struct Backbuffer {
         Ref<Image>       image {};
         vk::ImageView    view {};
-        Ref<Framebuffer> fb {};
+        vk::Framebuffer  framebuffer {};
         BackbufferStatus status {};
     };
 


### PR DESCRIPTION
these 4 classes are moved: PipelineLayout, PipelineReflection, RenderPass, Framebuffer