### PR TITLE
Image::readContent/setContent API improvements and CIT fixes

### DIFF
--- a/dev/bin/cit.py
+++ b/dev/bin/cit.py
@@ -12,24 +12,23 @@ def check_header_revision():
     git_remote = subprocess.check_output(["git", "remote"], cwd=sdk_root_dir).decode(sys.stdout.encoding).strip()
     header_path = "inc/rapid-vulkan/rapid-vulkan.h"
     header_diff = subprocess.check_output(["git", "diff", "-U0", "--no-color", git_remote + "/main", "--", header_path], cwd=sdk_root_dir).decode(sys.stdout.encoding).strip()
-    if 0 == len(header_diff):
-        print("OK.")
-        return
 
     # get header revision of the local file
     with open(sdk_root_dir / header_path, "r") as f: local_revision = get_header_revision(f.read())
-    # print(f"Local header revision: {local_revision}")
 
-    # get header revision of the remote file
+    # get header revision of the remote main
     remote_header = subprocess.check_output(["git", "show", git_remote + "/main:" + str(header_path)], cwd=sdk_root_dir).decode(sys.stdout.encoding).strip()
     remote_revision = get_header_revision(remote_header)
-    # print(f"Remote header revision: {remote_revision}")
+
+    if 0 == len(header_diff):
+        print(f"OK (revision {local_revision}, no change from main).")
+        return
 
     # check if the header revision is increased
     if local_revision <= remote_revision:
-        utils.rip("The header revision is not increased. Please increase the header revision.")
+        utils.rip(f"Header revision not increased (local={local_revision}, main={remote_revision}). Please bump RAPID_VULKAN_HEADER_REVISION.")
     else:
-        print("OK")
+        print(f"OK (revision {remote_revision} -> {local_revision}).")
 
 def run_style_check():
     print("Checking code styles...", end="")

--- a/dev/test/graphics-test.cpp
+++ b/dev/test/graphics-test.cpp
@@ -36,12 +36,16 @@ TEST_CASE("clear-screen") {
         q.submit({c}).wait();
     };
 
+    // readContent() requires the caller to specify the current image layout. After cmdEndBuiltInRenderPass,
+    // the backbuffer is in ePresentSrcKHR layout.
+    auto readBackbuffer = [](const Image * img) { return img->readContent(Image::ReadContentParameters {}.setCurrentLayout(vk::ImageLayout::ePresentSrcKHR)); };
+
     auto frame = sw.beginFrame();
 
     // case 1. clear only.
     SECTION("clear-only") {
         render(std::array<float, 4> {0.f, 1.f, 0.f, 1.f}, false); // clear to green
-        auto pixels = frame.backbuffer->image->readContent({});
+        auto pixels = readBackbuffer(frame.backbuffer->image);
         REQUIRE(pixels.storage.size() >= 4);
         CHECK(0xFF00FF00 == *(const uint32_t *) pixels.storage.data()); // verify that the screen is green.
     }
@@ -51,7 +55,7 @@ TEST_CASE("clear-screen") {
         RenderDocCapture rdc;
         rdc.begin("clear-screen-section-2");
         render(std::array<float, 4> {1.f, 0.f, 0.f, 1.f}, true); // clear to red, then draw a full screen blue triangle.
-        auto pixels = frame.backbuffer->image->readContent({});
+        auto pixels = readBackbuffer(frame.backbuffer->image);
         REQUIRE(pixels.storage.size() >= 4);
         CHECK(0xFFFF0000 == *(const uint32_t *) pixels.storage.data());
         rdc.end();
@@ -106,12 +110,12 @@ TEST_CASE("vertex-buffer") {
     sw.cmdBeginBuiltInRenderPass(c, Swapchain::BeginRenderPassParameters {}.setClearColorF({0.0f, 1.0f, 0.0f, 1.0f})); // clear to green
     c.handle().bindVertexBuffers(0, {vb.handle()}, {0});                                                               // bind the vertex buffer
     p.cmdDraw(c, GraphicsPipeline::DrawParameters {}.setNonIndexed(3));                                                // then draw a blue triangle.
-    sw.cmdEndBuiltInRenderPass(c);
+    auto bbStatus = sw.cmdEndBuiltInRenderPass(c);
     q.submit({c, {}, {f.imageAvailable}, {}}).wait();
     rdc.end();
 
-    // read content of back buffer.
-    auto pixels = f.backbuffer->image->readContent({});
+    // read content of back buffer. Pass the post-render layout returned by cmdEndBuiltInRenderPass.
+    auto pixels = f.backbuffer->image->readContent(Image::ReadContentParameters {}.setCurrentLayout(bbStatus.layout));
 
     // Since we clear the whole screen to green, then draw a blue triangle to cover the lower left half of the screen,
     // then pixel (1, 0) should be green, and pixel (0, 1) should be blue.

--- a/dev/test/image-test.cpp
+++ b/dev/test/image-test.cpp
@@ -27,8 +27,8 @@ TEST_CASE("image-read-write") {
     const uint32_t pixels[] = {0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff};
     image.setContent(Image::SetContentParameters {}.setQueue(*dev->graphics()).setPixels(pixels));
 
-    // then read it back
-    auto read = image.readContent(Image::ReadContentParameters {}.setQueue(*dev->graphics()));
+    // setContent() leaves the image in eTransferDstOptimal; readContent() needs the actual current layout.
+    auto read = image.readContent(Image::ReadContentParameters {}.setQueue(*dev->graphics()).setCurrentLayout(vk::ImageLayout::eTransferDstOptimal));
     REQUIRE(read.format == cp.info.format);
     REQUIRE(read.storage.size() == 4 * cp.info.extent.width * cp.info.extent.height);
     auto p = (const uint32_t *) read.storage.data();

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -861,13 +861,13 @@ public:
         return view;
     }
 
-    void setContent(const SetContentParameters & params) {
+    bool setContent(const SetContentParameters & params) {
         // make sure area is aligned to block size
         auto formatDesc = VkFormatDesc::get(_desc.format);
         if ((params.area.x % formatDesc.blockW) != 0 || (params.area.y % formatDesc.blockH) != 0 || (params.area.w % formatDesc.blockW) != 0 ||
             (params.area.h % formatDesc.blockH) != 0) {
             RVI_LOGE("Image::setContent: area is not aligned to block size");
-            return;
+            return false;
         }
 
         // validate row pitch
@@ -878,14 +878,14 @@ public:
         if (0 == rowPitch) { rowPitch = width * formatDesc.sizeBytes; }
         if (rowPitch < width * formatDesc.sizeBytes) {
             RVI_LOGE("Image::setContent: row pitch is too small");
-            return;
+            return false;
         }
 
         // TODO: validate mip level and array layer.
 
         // adjust area to fit image size
         auto area = clampRect3D(params.area, mipExtent);
-        if (area.w == 0 || area.h == 0 || area.d == 0) return;
+        if (area.w == 0 || area.h == 0 || area.d == 0) return false;
 
         // adjust pixel array pointer and size based on the clamped area.
         // (TODO: revisit this math. could be wrong)
@@ -913,18 +913,22 @@ public:
         // copy image content from staging buffer to image
         auto q = CommandQueue({{_owner.name()}, _gi, params.queueFamily, params.queueIndex});
         auto c = q.begin(_owner.name().data());
-        if (c) {
-            CmdDebugLabel label(c, ("set image content of " + _owner.name()).c_str());
-            auto          r = vk::ImageSubresourceRange(aspect, params.mipLevel, 1, params.arrayLayer, 1);
-            Barrier {}
-                .s(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eTransfer)
-                .i(_desc.handle, vk::AccessFlagBits::eMemoryWrite | vk::AccessFlagBits::eShaderWrite, vk::AccessFlagBits::eTransferRead,
-                   vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, r)
-                .cmdWrite(c);
-            c.handle().copyBufferToImage(staging, _desc.handle, vk::ImageLayout::eTransferDstOptimal, {copyRegion});
-            label.end();
-            q.wait(q.submit({{c}}));
+        if (!c) {
+            RVI_LOGE("Image::setContent: failed to begin command buffer");
+            return false;
         }
+
+        CmdDebugLabel label(c, ("set image content of " + _owner.name()).c_str());
+        auto          r = vk::ImageSubresourceRange(aspect, params.mipLevel, 1, params.arrayLayer, 1);
+        Barrier {}
+            .s(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eTransfer)
+            .i(_desc.handle, vk::AccessFlagBits::eMemoryWrite | vk::AccessFlagBits::eShaderWrite, vk::AccessFlagBits::eTransferRead,
+               vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal, r)
+            .cmdWrite(c);
+        c.handle().copyBufferToImage(staging, _desc.handle, vk::ImageLayout::eTransferDstOptimal, {copyRegion});
+        label.end();
+        q.wait(q.submit({{c}}));
+        return true;
     }
 
     Content readContent(const ReadContentParameters & params) const {
@@ -970,10 +974,8 @@ public:
             auto r = vk::ImageSubresourceRange(aspect, 0, _desc.mipLevels, 0, _desc.arrayLayers);
             Barrier {}
                 .s(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eTransfer)
-                .i(_desc.handle, vk::AccessFlagBits::eMemoryWrite | vk::AccessFlagBits::eShaderWrite, vk::AccessFlagBits::eTransferRead,
-                   // TOOD: undefined state allows driver to discard the content. Need to use in the actual
-                   // layout of the image. AFter the copy, also need to restore the original layout.
-                   vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferSrcOptimal, r)
+                .i(_desc.handle, vk::AccessFlagBits::eMemoryWrite | vk::AccessFlagBits::eShaderWrite, vk::AccessFlagBits::eTransferRead, params.currentLayout,
+                   vk::ImageLayout::eTransferSrcOptimal, r)
                 .cmdWrite(c);
             c.handle().copyImageToBuffer(_desc.handle, vk::ImageLayout::eTransferSrcOptimal, staging, copyRegions);
             q.wait(q.submit({c}));
@@ -1124,7 +1126,7 @@ Image::~Image() {
 }
 auto Image::desc() const -> const Desc & { return _impl->desc(); }
 auto Image::getView(const GetViewParameters & p) const -> vk::ImageView { return _impl->getView(p); }
-void Image::setContent(const SetContentParameters & p) { return _impl->setContent(p); }
+bool Image::setContent(const SetContentParameters & p) { return _impl->setContent(p); }
 auto Image::readContent(const ReadContentParameters & p) const -> Content { return _impl->readContent(p); }
 void Image::onNameChanged(const std::string &) { _impl->onNameChanged(); }
 // *********************************************************************************************************************

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -26,7 +26,7 @@ SOFTWARE.
 #define RAPID_VULKAN_H_
 
 /// A monotonically increasing number that uniquely identifies the revision of the header.
-#define RAPID_VULKAN_HEADER_REVISION 29
+#define RAPID_VULKAN_HEADER_REVISION 30
 
 /// \def RAPID_VULKAN_NAMESPACE
 /// Define the namespace of rapid-vulkan library.
@@ -1360,8 +1360,9 @@ public:
     };
 
     struct ReadContentParameters {
-        uint32_t queueFamily = 0;
-        uint32_t queueIndex  = 0;
+        uint32_t        queueFamily   = 0;
+        uint32_t        queueIndex    = 0;
+        vk::ImageLayout currentLayout = vk::ImageLayout::eTransferSrcOptimal;
 
         ReadContentParameters & setQueue(uint32_t family, uint32_t index) {
             queueFamily = family;
@@ -1370,6 +1371,11 @@ public:
         }
 
         ReadContentParameters & setQueue(const CommandQueue &);
+
+        ReadContentParameters & setCurrentLayout(vk::ImageLayout l) {
+            currentLayout = l;
+            return *this;
+        }
     };
 
     struct SubresourceContent {
@@ -1382,13 +1388,15 @@ public:
 
     struct Content {
         /// @brief The format of the pixel.
-        vk::Format format;
+        vk::Format format = vk::Format::eUndefined;
 
         /// @brief The storage of all pixels.
         std::vector<uint8_t> storage;
 
         /// @brief content of each subresource. index by (mipLevel * layerCount + arrayLayer)
         std::vector<SubresourceContent> subresources;
+
+        operator bool() const { return format != vk::Format::eUndefined && !storage.empty() && !subresources.empty(); }
     };
 
     /// @brief A utility function to determine image aspect flags from a format.
@@ -1414,10 +1422,11 @@ public:
 
     /// @brief Synchronously set content of one subresource
     /// This method, if succeeded, will transfer the subresource into vk::ImageLayout::eTransferDstOptimal layout.
-    void setContent(const SetContentParameters &);
+    bool setContent(const SetContentParameters &);
 
     /// @brief Synchronously read content of the whole image.
-    /// This method, if succeeded, will transfer the image into vk::ImageLayout::eTransferSrcOptimal layout.
+    /// This method, if succeeded, will transfer the entire image into vk::ImageLayout::eTransferSrcOptimal layout.
+    /// If failed, returns empty content with undefined format.
     Content readContent(const ReadContentParameters &) const;
 
     vk::Image handle() const { return desc().handle; }


### PR DESCRIPTION
## Summary

- **`Image::setContent` now returns `bool`** — callers can detect failure (bad area alignment, pitch too small, command buffer failure) instead of silently ignoring it.
- **`Image::readContent` now accepts a `currentLayout` parameter** — the previous implementation forced `eUndefined` as the source layout, which is only safe when the driver is allowed to discard content. Callers now pass the actual layout, fixing incorrect barrier transitions for images that are in a known layout (e.g. `eTransferDstOptimal` after `setContent`, `ePresentSrcKHR` after a render pass).
- **`Content` struct gains `operator bool()`** — convenient empty-check.
- **Bumps `RAPID_VULKAN_HEADER_REVISION` to 30.**
- **CIT fixes** — updates `graphics-test.cpp`, `image-test.cpp`, and `cit.py` to use the new API and to report revision numbers in the header-check output.

## Test plan

- [ ] `cit.py` passes with the updated header revision check.
- [ ] `image-read-write` test passes with `eTransferDstOptimal` layout passed to `readContent`.
- [ ] `clear-screen` and `vertex-buffer` tests pass with `ePresentSrcKHR` / swapchain-returned layout passed to `readContent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)