### PR TITLE
Improve Vulkan submission and resource lifetime handling

### DIFF
--- a/dev/sample/clear-screen.cpp
+++ b/dev/sample/clear-screen.cpp
@@ -73,9 +73,8 @@ void entry(const Options & options) {
     glfw.show();
     for (;;) {
         if (!options.headless && !glfw.processEvents()) break;
-        auto                                      frame        = sw.beginFrame();
-        float                                     clearColor[] = {0.0f, 1.0f, 0.0f, 1.0f};
-        rapid_vulkan::Swapchain::BackbufferStatus backbufferStatus;
+        auto  frame        = sw.beginFrame();
+        float clearColor[] = {0.0f, 1.0f, 0.0f, 1.0f};
         if (frame.valid()) {
             // Standard boilerplate of rendering a frame. It is basically the same as triangle.cpp.
             if (options.headless) {
@@ -94,15 +93,15 @@ void entry(const Options & options) {
             // begin the render pass
             sw.cmdBeginBuiltInRenderPass(c, Swapchain::BeginRenderPassParameters {}.setClearColorF(clearColor)); // clear the screen.
 
-            // end render pass
-            backbufferStatus = sw.cmdEndBuiltInRenderPass(c);
+            // end render pass (also updates image state to DESIRED_PRESENT_STATUS)
+            sw.cmdEndBuiltInRenderPass(c);
 
             // submit the command buffer. also signal the render finished semaphore.
             q.submit({c, {}, {frame.imageAvailable}, {renderFinished.get()}});
         }
 
         // end of the frame.
-        sw.present(Swapchain::PresentParameters(backbufferStatus).setRenderFinished({renderFinished.get()}));
+        sw.present(Swapchain::PresentParameters {}.setRenderFinished({renderFinished.get()}));
     }
     device.waitIdle();
 }

--- a/dev/sample/clear-screen.cpp
+++ b/dev/sample/clear-screen.cpp
@@ -97,7 +97,9 @@ void entry(const Options & options) {
             sw.cmdEndBuiltInRenderPass(c);
 
             // submit the command buffer. also signal the render finished semaphore.
-            q.submit({c, {}, {frame.imageAvailable}, {renderFinished.get()}});
+            CommandQueue::SyncPoint iaSp {frame.imageAvailable};
+            CommandQueue::SyncPoint rfSp {renderFinished.get()};
+            q.submit({c, {}, {1, &iaSp}, {}, {1, &rfSp}});
         }
 
         // end of the frame.

--- a/dev/sample/clear-screen.cpp
+++ b/dev/sample/clear-screen.cpp
@@ -99,7 +99,7 @@ void entry(const Options & options) {
             // submit the command buffer. also signal the render finished semaphore.
             CommandQueue::SyncPoint iaSp {frame.imageAvailable};
             CommandQueue::SyncPoint rfSp {renderFinished.get()};
-            q.submit({c, {}, {1, &iaSp}, {}, {1, &rfSp}});
+            q.submit1({c, {}, {1, &iaSp}, {}, {1, &rfSp}});
         }
 
         // end of the frame.

--- a/dev/sample/drawable.cpp
+++ b/dev/sample/drawable.cpp
@@ -137,7 +137,9 @@ void entry(const Options & options) {
             sw.cmdEndBuiltInRenderPass(c);
 
             // submit the command buffer
-            q.submit({c, {}, {frame.imageAvailable}, {renderFinished.get()}});
+            CommandQueue::SyncPoint iaSp {frame.imageAvailable};
+            CommandQueue::SyncPoint rfSp {renderFinished.get()};
+            q.submit({c, {}, {1, &iaSp}, {}, {1, &rfSp}});
         }
 
         // end of the frame.

--- a/dev/sample/drawable.cpp
+++ b/dev/sample/drawable.cpp
@@ -139,7 +139,7 @@ void entry(const Options & options) {
             // submit the command buffer
             CommandQueue::SyncPoint iaSp {frame.imageAvailable};
             CommandQueue::SyncPoint rfSp {renderFinished.get()};
-            q.submit({c, {}, {1, &iaSp}, {}, {1, &rfSp}});
+            q.submit1({c, {}, {1, &iaSp}, {}, {1, &rfSp}});
         }
 
         // end of the frame.

--- a/dev/sample/drawable.cpp
+++ b/dev/sample/drawable.cpp
@@ -106,8 +106,7 @@ void entry(const Options & options) {
     glfw.show();
     for (;;) {
         if (!options.headless && !glfw.processEvents()) break;
-        auto                                      frame = sw.beginFrame();
-        rapid_vulkan::Swapchain::BackbufferStatus backbufferStatus;
+        auto frame = sw.beginFrame();
         if (frame.valid()) {
             // Standard boilerplate of rendering a frame. It is basically the same as triangle.cpp.
             if (options.headless) {
@@ -134,15 +133,15 @@ void entry(const Options & options) {
             // enqueue the draw pack to command buffer.
             c.render(dp);
 
-            // end render pass
-            backbufferStatus = sw.cmdEndBuiltInRenderPass(c);
+            // end render pass (also updates image state to DESIRED_PRESENT_STATUS)
+            sw.cmdEndBuiltInRenderPass(c);
 
             // submit the command buffer
             q.submit({c, {}, {frame.imageAvailable}, {renderFinished.get()}});
         }
 
         // end of the frame.
-        sw.present(Swapchain::PresentParameters(backbufferStatus).setRenderFinished({renderFinished.get()}));
+        sw.present(Swapchain::PresentParameters {}.setRenderFinished({renderFinished.get()}));
     }
     device.waitIdle();
 }

--- a/dev/sample/noop-compute.cpp
+++ b/dev/sample/noop-compute.cpp
@@ -10,7 +10,7 @@ int main() {
     auto q        = CommandQueue({{"main"}, gi, device.graphics()->family(), device.graphics()->index()});
     if (auto c = q.begin("main")) {
         p.cmdDispatch(c, {1, 1, 1});
-        q.submit({c});
+        q.submit1({c});
     }
     q.waitIdle();
     return 0;

--- a/dev/sample/triangle.cpp
+++ b/dev/sample/triangle.cpp
@@ -101,7 +101,7 @@ void entry(const Options & options) {
             sw.cmdEndBuiltInRenderPass(c); // also updates image state to DESIRED_PRESENT_STATUS
             CommandQueue::SyncPoint iaSp {frame.imageAvailable};
             CommandQueue::SyncPoint rfSp {renderFinished.get()};
-            q.submit({c, {}, {1, &iaSp}, {}, {1, &rfSp}});
+            q.submit1({c, {}, {1, &iaSp}, {}, {1, &rfSp}});
         }
         sw.present(Swapchain::PresentParameters {}.setRenderFinished({renderFinished.get()}));
     }

--- a/dev/sample/triangle.cpp
+++ b/dev/sample/triangle.cpp
@@ -89,8 +89,7 @@ void entry(const Options & options) {
     glfw.show();
     for (;;) {
         if (!options.headless && !glfw.processEvents()) break;
-        auto                                      frame = sw.beginFrame();
-        rapid_vulkan::Swapchain::BackbufferStatus backbufferStatus;
+        auto frame = sw.beginFrame();
         if (frame.valid()) {
             if (options.headless) {
                 if (frame.index > options.headless) break; // only render number of required frames in headless mode, then quite.
@@ -99,10 +98,10 @@ void entry(const Options & options) {
             auto c = q.begin("triangle");
             sw.cmdBeginBuiltInRenderPass(c, Swapchain::BeginRenderPassParameters {}.setClearColorF({0.0f, 1.0f, 0.0f, 1.0f})); // clear to green
             p.cmdDraw(c, GraphicsPipeline::DrawParameters {}.setNonIndexed(3));                                                // then draw a blue triangle.
-            backbufferStatus = sw.cmdEndBuiltInRenderPass(c);
+            sw.cmdEndBuiltInRenderPass(c); // also updates image state to DESIRED_PRESENT_STATUS
             q.submit({c, {}, {frame.imageAvailable}, {renderFinished.get()}});
         }
-        sw.present(Swapchain::PresentParameters(backbufferStatus).setRenderFinished({renderFinished.get()}));
+        sw.present(Swapchain::PresentParameters {}.setRenderFinished({renderFinished.get()}));
     }
     device.waitIdle(); // don't forget to wait for the device to be idle before destroying vulkan objects.
 }

--- a/dev/sample/triangle.cpp
+++ b/dev/sample/triangle.cpp
@@ -99,7 +99,9 @@ void entry(const Options & options) {
             sw.cmdBeginBuiltInRenderPass(c, Swapchain::BeginRenderPassParameters {}.setClearColorF({0.0f, 1.0f, 0.0f, 1.0f})); // clear to green
             p.cmdDraw(c, GraphicsPipeline::DrawParameters {}.setNonIndexed(3));                                                // then draw a blue triangle.
             sw.cmdEndBuiltInRenderPass(c); // also updates image state to DESIRED_PRESENT_STATUS
-            q.submit({c, {}, {frame.imageAvailable}, {renderFinished.get()}});
+            CommandQueue::SyncPoint iaSp {frame.imageAvailable};
+            CommandQueue::SyncPoint rfSp {renderFinished.get()};
+            q.submit({c, {}, {1, &iaSp}, {}, {1, &rfSp}});
         }
         sw.present(Swapchain::PresentParameters {}.setRenderFinished({renderFinished.get()}));
     }

--- a/dev/test/compute-test.cpp
+++ b/dev/test/compute-test.cpp
@@ -17,7 +17,7 @@ TEST_CASE("noop-compute") {
     auto q = CommandQueue({{"main"}, gi, device->graphics()->family(), device->graphics()->index()});
     if (auto c = q.begin("main")) {
         p.cmdDispatch(c, {1, 1, 1});
-        q.submit({c});
+        q.submit1({c});
     }
     q.waitIdle();
 }
@@ -58,7 +58,7 @@ TEST_CASE("cs-buffer-args") {
         ap        = nullptr; // release drawable object to verify that all resource are kept alive by the draw pack object.
         c.render(pack);
         pack = nullptr; // release draw pack object to verify that all resource are kept alive by the command buffer.
-        q->submit({c});
+        q->submit1({c});
     }
 
     REQUIRE(Buffer::instanceCount() == numBuffers + 2);

--- a/dev/test/graphics-test.cpp
+++ b/dev/test/graphics-test.cpp
@@ -110,7 +110,8 @@ TEST_CASE("vertex-buffer") {
     c.handle().bindVertexBuffers(0, {vb.handle()}, {0});                                                               // bind the vertex buffer
     p.cmdDraw(c, GraphicsPipeline::DrawParameters {}.setNonIndexed(3));                                                // then draw a blue triangle.
     sw.cmdEndBuiltInRenderPass(c);
-    q.submit({c, {}, {f.imageAvailable}, {}}).wait();
+    CommandQueue::SyncPoint iaSp {f.imageAvailable};
+    q.submit({c, {}, {1, &iaSp}}).wait();
     rdc.end();
 
     // readContent() derives the current layout from the image's own tracked state (set by cmdEndBuiltInRenderPass).

--- a/dev/test/graphics-test.cpp
+++ b/dev/test/graphics-test.cpp
@@ -33,7 +33,7 @@ TEST_CASE("clear-screen") {
         sw.cmdBeginBuiltInRenderPass(c, bp);
         if (drawTriangle) p.cmdDraw(c, GraphicsPipeline::DrawParameters {}.setNonIndexed(3)); // draw a full screen blue triangle.
         sw.cmdEndBuiltInRenderPass(c);
-        q.submit({c}).wait();
+        q.submit1({c}).wait();
     };
 
     // readContent() derives the current image layout from the image's own tracked state.
@@ -111,7 +111,7 @@ TEST_CASE("vertex-buffer") {
     p.cmdDraw(c, GraphicsPipeline::DrawParameters {}.setNonIndexed(3));                                                // then draw a blue triangle.
     sw.cmdEndBuiltInRenderPass(c);
     CommandQueue::SyncPoint iaSp {f.imageAvailable};
-    q.submit({c, {}, {1, &iaSp}}).wait();
+    q.submit1({c, {}, {1, &iaSp}}).wait();
     rdc.end();
 
     // readContent() derives the current layout from the image's own tracked state (set by cmdEndBuiltInRenderPass).

--- a/dev/test/graphics-test.cpp
+++ b/dev/test/graphics-test.cpp
@@ -36,9 +36,8 @@ TEST_CASE("clear-screen") {
         q.submit({c}).wait();
     };
 
-    // readContent() requires the caller to specify the current image layout. After cmdEndBuiltInRenderPass,
-    // the backbuffer is in ePresentSrcKHR layout.
-    auto readBackbuffer = [](const Image * img) { return img->readContent(Image::ReadContentParameters {}.setCurrentLayout(vk::ImageLayout::ePresentSrcKHR)); };
+    // readContent() derives the current image layout from the image's own tracked state.
+    auto readBackbuffer = [](Image * img) { return img->readContent(Image::ReadContentParameters {}); };
 
     auto frame = sw.beginFrame();
 
@@ -110,12 +109,12 @@ TEST_CASE("vertex-buffer") {
     sw.cmdBeginBuiltInRenderPass(c, Swapchain::BeginRenderPassParameters {}.setClearColorF({0.0f, 1.0f, 0.0f, 1.0f})); // clear to green
     c.handle().bindVertexBuffers(0, {vb.handle()}, {0});                                                               // bind the vertex buffer
     p.cmdDraw(c, GraphicsPipeline::DrawParameters {}.setNonIndexed(3));                                                // then draw a blue triangle.
-    auto bbStatus = sw.cmdEndBuiltInRenderPass(c);
+    sw.cmdEndBuiltInRenderPass(c);
     q.submit({c, {}, {f.imageAvailable}, {}}).wait();
     rdc.end();
 
-    // read content of back buffer. Pass the post-render layout returned by cmdEndBuiltInRenderPass.
-    auto pixels = f.backbuffer->image->readContent(Image::ReadContentParameters {}.setCurrentLayout(bbStatus.layout));
+    // readContent() derives the current layout from the image's own tracked state (set by cmdEndBuiltInRenderPass).
+    auto pixels = f.backbuffer->image->readContent(Image::ReadContentParameters {});
 
     // Since we clear the whole screen to green, then draw a blue triangle to cover the lower left half of the screen,
     // then pixel (1, 0) should be green, and pixel (0, 1) should be blue.

--- a/dev/test/image-test.cpp
+++ b/dev/test/image-test.cpp
@@ -27,8 +27,8 @@ TEST_CASE("image-read-write") {
     const uint32_t pixels[] = {0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff};
     image.setContent(Image::SetContentParameters {}.setQueue(*dev->graphics()).setPixels(pixels));
 
-    // setContent() leaves the image in eTransferDstOptimal; readContent() needs the actual current layout.
-    auto read = image.readContent(Image::ReadContentParameters {}.setQueue(*dev->graphics()).setCurrentLayout(vk::ImageLayout::eTransferDstOptimal));
+    // readContent() reads the internal state for current layout (auto-updated by setContent).
+    auto read = image.readContent(Image::ReadContentParameters {}.setQueue(*dev->graphics()));
     REQUIRE(read.format == cp.info.format);
     REQUIRE(read.storage.size() == 4 * cp.info.extent.width * cp.info.extent.height);
     auto p = (const uint32_t *) read.storage.data();
@@ -36,4 +36,70 @@ TEST_CASE("image-read-write") {
     CHECK(p[1] == pixels[1]);
     CHECK(p[2] == pixels[2]);
     CHECK(p[3] == pixels[3]);
+}
+
+TEST_CASE("image-state-initial") {
+    using namespace rapid_vulkan;
+    auto cp    = Image::ConstructParameters {{"st"}, TestVulkanInstance::device->gi()}.set2D(4, 4);
+    auto image = Image(cp);
+
+    // Freshly constructed image starts in UNDEFINED layout on every plane.
+    const auto & st = image.getState();
+    CHECK(st.validAspects == vk::ImageAspectFlagBits::eColor);
+    const auto * plane = st.get(0, 0, vk::ImageAspectFlagBits::eColor);
+    REQUIRE(plane);
+    CHECK(plane->layout == vk::ImageLayout::eUndefined);
+    // Out-of-range queries return nullptr.
+    CHECK(!st.get(99, 0, vk::ImageAspectFlagBits::eColor));
+    CHECK(!st.get(0, 0, vk::ImageAspectFlagBits::eDepth)); // color image has no depth plane
+}
+
+TEST_CASE("image-state-after-setContent") {
+    using namespace rapid_vulkan;
+    auto dev   = TestVulkanInstance::device.get();
+    auto cp    = Image::ConstructParameters {{"sc"}, dev->gi()}.set2D(2, 2);
+    auto image = Image(cp);
+
+    const uint32_t pixels[] = {1, 2, 3, 4};
+    image.setContent(Image::SetContentParameters {}.setQueue(*dev->graphics()).setPixels(pixels));
+
+    // setContent() transitions mip 0, layer 0 to TRANSFER_DST_OPTIMAL.
+    const auto * plane = image.getState().get(0, 0, vk::ImageAspectFlagBits::eColor);
+    REQUIRE(plane);
+    CHECK(plane->layout == vk::ImageLayout::eTransferDstOptimal);
+}
+
+TEST_CASE("image-state-after-readContent") {
+    using namespace rapid_vulkan;
+    auto dev   = TestVulkanInstance::device.get();
+    auto cp    = Image::ConstructParameters {{"rc"}, dev->gi()}.set2D(2, 2);
+    auto image = Image(cp);
+
+    const uint32_t pixels[] = {1, 2, 3, 4};
+    image.setContent(Image::SetContentParameters {}.setQueue(*dev->graphics()).setPixels(pixels));
+    image.readContent(Image::ReadContentParameters {}.setQueue(*dev->graphics()));
+
+    // readContent() transitions entire image to TRANSFER_SRC_OPTIMAL.
+    const auto * plane = image.getState().get(0, 0, vk::ImageAspectFlagBits::eColor);
+    REQUIRE(plane);
+    CHECK(plane->layout == vk::ImageLayout::eTransferSrcOptimal);
+}
+
+TEST_CASE("image-setState") {
+    using namespace rapid_vulkan;
+    auto cp    = Image::ConstructParameters {{"ss"}, TestVulkanInstance::device->gi()}.set2D(4, 4).setLevels(2);
+    auto image = Image(cp);
+
+    // Set mip 1 to TRANSFER_DST.
+    image.setState(Image::State::PlaneState::TRANSFER_DST(), vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 1, 1, 0, 1));
+
+    // Mip 0 is still UNDEFINED.
+    const auto * mip0 = image.getState().get(0, 0, vk::ImageAspectFlagBits::eColor);
+    REQUIRE(mip0);
+    CHECK(mip0->layout == vk::ImageLayout::eUndefined);
+
+    // Mip 1 is now TRANSFER_DST_OPTIMAL.
+    const auto * mip1 = image.getState().get(1, 0, vk::ImageAspectFlagBits::eColor);
+    REQUIRE(mip1);
+    CHECK(mip1->layout == vk::ImageLayout::eTransferDstOptimal);
 }

--- a/dev/test/perf-test.cpp
+++ b/dev/test/perf-test.cpp
@@ -66,5 +66,5 @@ TEST_CASE("texture-array", "[perf]") {
         for (size_t i = 0; i < 100000; ++i) { c.render(d->compile()); }
     }
     sw.cmdEndBuiltInRenderPass(c.handle());
-    q->submit({c}).wait();
+    q->submit1({c}).wait();
 }

--- a/dev/test/queue-test.cpp
+++ b/dev/test/queue-test.cpp
@@ -5,14 +5,14 @@
 TEST_CASE("queue-duplicated-command-buffers") {
     auto q = TestVulkanInstance::device->graphics()->clone();
     auto c = q.begin(nullptr); // testing null name is safe
-    q.submit({{c, c}});
-    q.submit({{c, c}});
+    q.submit1({{c, c}});
+    q.submit1({{c, c}});
 }
 
 TEST_CASE("queue-wait-idle") {
     auto q = TestVulkanInstance::device->graphics()->clone();
     auto c = q.begin(nullptr); // testing null name is safe
-    auto s = q.submit({c});
+    auto s = q.submit1({c});
     q.waitIdle(); // wait for the queue to be idle.
     q.wait(s);    // wait on an already finished submission is safe and not an error.
 }
@@ -23,7 +23,7 @@ TEST_CASE("queue-reuse") {
     SECTION("reuse-finished") {
         auto c1 = q->begin("c1");
         auto h1 = c1.handle();
-        q->wait(q->submit({c1}));
+        q->wait(q->submit1({c1}));
         auto c2 = q->begin("c2"); // should reuse c1
         auto h2 = c2.handle();
         CHECK(h1 == h2); // make sure the handles are the same.
@@ -49,16 +49,16 @@ TEST_CASE("queue-reuse") {
     SECTION("should-not-reuse-pending") {
         auto c1 = q->begin("c1");
         auto h1 = c1.handle();
-        q->submit({c1});
+        q->submit1({c1});
         auto c2 = q->begin("c2"); // should not reuse c1
         auto h2 = c2.handle();
         CHECK(h1 != h2);
     }
 }
 
-/// Verify the v1/v2 submit path handles binary semaphore wait + signal correctly.
+/// Verify submit1 handles binary semaphore wait + signal correctly.
 /// One submit signals a binary semaphore; the next waits on it.
-TEST_CASE("queue-submit-binary-semaphore") {
+TEST_CASE("queue-submit1-binary-semaphore") {
     using namespace rapid_vulkan;
     auto q  = TestVulkanInstance::device->graphics();
     auto gi = TestVulkanInstance::device->gi();
@@ -67,28 +67,24 @@ TEST_CASE("queue-submit-binary-semaphore") {
 
     CommandQueue::SyncPoint signalSp {sem.get()};
     auto                    c1 = q->begin("signal");
-    q->submit({c1, {}, {}, {}, {1, &signalSp}});
+    q->submit1({c1, {}, {}, {}, {1, &signalSp}});
 
-    // Second submit waits on the binary semaphore just signaled above.
     CommandQueue::SyncPoint waitSp {sem.get()};
     auto                    c2 = q->begin("wait");
-    q->submit({c2, {}, {1, &waitSp}});
+    q->submit1({c2, {}, {1, &waitSp}});
 
     q->waitIdle();
     CHECK(true); // reaching here means no GPU hang / deadlock
 }
 
-/// Verify the v1/v2 submit path handles timeline semaphore signal and wait correctly.
-/// One submit signals a timeline semaphore at value 1; the next waits for value 1.
-TEST_CASE("queue-submit-timeline-semaphore") {
+/// Verify submit2 handles timeline semaphore signal + wait via VkTimelineSemaphoreSubmitInfo.
+TEST_CASE("queue-submit1-timeline-semaphore") {
     using namespace rapid_vulkan;
     auto q  = TestVulkanInstance::device->graphics();
     auto gi = TestVulkanInstance::device->gi();
 
-    // Timeline semaphores require Vulkan 1.2+ (or VK_KHR_timeline_semaphore).
-    // Skip gracefully on older implementations.
-    if (!gi->timelineSemaphore) {
-        fprintf(stderr, "The current Vulkan API does not support timeline semaphore.\n");
+    if (!TestVulkanInstance::timelineSemaphore) {
+        fprintf(stderr, "timeline semaphore not available, skipping.\n");
         return;
     }
 
@@ -97,15 +93,66 @@ TEST_CASE("queue-submit-timeline-semaphore") {
     semInfo.setPNext(&timelineInfo);
     auto timeline = gi->device.createSemaphoreUnique(semInfo, gi->allocator);
 
-    // Submit 1: signal timeline at value 1.
     CommandQueue::SyncPoint signalPt {timeline.get(), 1};
     auto                    c1 = q->begin("timeline-signal");
-    q->submit({c1, {}, {}, {}, {}, {1, &signalPt}});
+    q->submit2({c1, {}, {}, {}, {}, {1, &signalPt}});
 
-    // Submit 2: wait for timeline value 1, then complete.
     CommandQueue::SyncPoint waitPt {timeline.get(), 1};
     auto                    c2 = q->begin("timeline-wait");
-    q->submit({c2, {}, {}, {1, &waitPt}});
+    q->submit2({c2, {}, {}, {1, &waitPt}});
+
+    q->waitIdle();
+    CHECK(true); // reaching here means no GPU hang / deadlock
+}
+
+/// Verify submit2 handles binary semaphore wait + signal via VkSubmitInfo2.
+TEST_CASE("queue-submit2-binary-semaphore") {
+    using namespace rapid_vulkan;
+    auto q  = TestVulkanInstance::device->graphics();
+    auto gi = TestVulkanInstance::device->gi();
+
+    if (!TestVulkanInstance::synchronization2) {
+        fprintf(stderr, "synchronization2 not available, skipping.\n");
+        return;
+    }
+
+    auto sem = gi->device.createSemaphoreUnique({}, gi->allocator);
+
+    CommandQueue::SyncPoint signalSp {sem.get()};
+    auto                    c1 = q->begin("signal2");
+    q->submit2({c1, {}, {}, {}, {1, &signalSp}});
+
+    CommandQueue::SyncPoint waitSp {sem.get()};
+    auto                    c2 = q->begin("wait2");
+    q->submit2({c2, {}, {1, &waitSp}});
+
+    q->waitIdle();
+    CHECK(true); // reaching here means no GPU hang / deadlock
+}
+
+/// Verify submit2 handles timeline semaphore signal + wait via VkSubmitInfo2.
+TEST_CASE("queue-submit2-timeline-semaphore") {
+    using namespace rapid_vulkan;
+    auto q  = TestVulkanInstance::device->graphics();
+    auto gi = TestVulkanInstance::device->gi();
+
+    if (!TestVulkanInstance::synchronization2 || !TestVulkanInstance::timelineSemaphore) {
+        fprintf(stderr, "synchronization2 or timelineSemaphore not available, skipping.\n");
+        return;
+    }
+
+    vk::SemaphoreTypeCreateInfo timelineInfo {vk::SemaphoreType::eTimeline, 0};
+    vk::SemaphoreCreateInfo     semInfo {};
+    semInfo.setPNext(&timelineInfo);
+    auto timeline = gi->device.createSemaphoreUnique(semInfo, gi->allocator);
+
+    CommandQueue::SyncPoint signalPt {timeline.get(), 1};
+    auto                    c1 = q->begin("timeline-signal2");
+    q->submit2({c1, {}, {}, {}, {}, {1, &signalPt}});
+
+    CommandQueue::SyncPoint waitPt {timeline.get(), 1};
+    auto                    c2 = q->begin("timeline-wait2");
+    q->submit2({c2, {}, {}, {1, &waitPt}});
 
     q->waitIdle();
     CHECK(true); // reaching here means no GPU hang / deadlock

--- a/dev/test/queue-test.cpp
+++ b/dev/test/queue-test.cpp
@@ -55,3 +55,58 @@ TEST_CASE("queue-reuse") {
         CHECK(h1 != h2);
     }
 }
+
+/// Verify the v1/v2 submit path handles binary semaphore wait + signal correctly.
+/// One submit signals a binary semaphore; the next waits on it.
+TEST_CASE("queue-submit-binary-semaphore") {
+    using namespace rapid_vulkan;
+    auto q  = TestVulkanInstance::device->graphics();
+    auto gi = TestVulkanInstance::device->gi();
+
+    auto sem = gi->device.createSemaphoreUnique({}, gi->allocator);
+
+    CommandQueue::SyncPoint signalSp {sem.get()};
+    auto                    c1 = q->begin("signal");
+    q->submit({c1, {}, {}, {}, {1, &signalSp}});
+
+    // Second submit waits on the binary semaphore just signaled above.
+    CommandQueue::SyncPoint waitSp {sem.get()};
+    auto                    c2 = q->begin("wait");
+    q->submit({c2, {}, {1, &waitSp}});
+
+    q->waitIdle();
+    CHECK(true); // reaching here means no GPU hang / deadlock
+}
+
+/// Verify the v1/v2 submit path handles timeline semaphore signal and wait correctly.
+/// One submit signals a timeline semaphore at value 1; the next waits for value 1.
+TEST_CASE("queue-submit-timeline-semaphore") {
+    using namespace rapid_vulkan;
+    auto q  = TestVulkanInstance::device->graphics();
+    auto gi = TestVulkanInstance::device->gi();
+
+    // Timeline semaphores require Vulkan 1.2+ (or VK_KHR_timeline_semaphore).
+    // Skip gracefully on older implementations.
+    if (!gi->timelineSemaphore) {
+        fprintf(stderr, "The current Vulkan API does not support timeline semaphore.\n");
+        return;
+    }
+
+    vk::SemaphoreTypeCreateInfo timelineInfo {vk::SemaphoreType::eTimeline, 0};
+    vk::SemaphoreCreateInfo     semInfo {};
+    semInfo.setPNext(&timelineInfo);
+    auto timeline = gi->device.createSemaphoreUnique(semInfo, gi->allocator);
+
+    // Submit 1: signal timeline at value 1.
+    CommandQueue::SyncPoint signalPt {timeline.get(), 1};
+    auto                    c1 = q->begin("timeline-signal");
+    q->submit({c1, {}, {}, {}, {}, {1, &signalPt}});
+
+    // Submit 2: wait for timeline value 1, then complete.
+    CommandQueue::SyncPoint waitPt {timeline.get(), 1};
+    auto                    c2 = q->begin("timeline-wait");
+    q->submit({c2, {}, {}, {1, &waitPt}});
+
+    q->waitIdle();
+    CHECK(true); // reaching here means no GPU hang / deadlock
+}

--- a/dev/test/queue-test.cpp
+++ b/dev/test/queue-test.cpp
@@ -130,6 +130,56 @@ TEST_CASE("queue-submit2-binary-semaphore") {
     CHECK(true); // reaching here means no GPU hang / deadlock
 }
 
+/// A truly empty submission (no commands, no semaphores) must return an empty SubmissionID.
+TEST_CASE("queue-submit-truly-empty-is-ignored") {
+    using namespace rapid_vulkan;
+    auto q = TestVulkanInstance::device->graphics()->clone();
+
+    auto id1 = q.submit1({});
+    auto id2 = q.submit2({});
+    CHECK(id1.empty());
+    CHECK(id2.empty());
+}
+
+/// Bridge-only submission (no command buffer, but with timeline-wait + binary-signal) must succeed.
+/// This pattern is needed to bridge a timeline sync point to a binary semaphore for vkQueuePresentKHR.
+TEST_CASE("queue-submit2-bridge-only") {
+    using namespace rapid_vulkan;
+    auto q  = TestVulkanInstance::device->graphics()->clone();
+    auto gi = TestVulkanInstance::device->gi();
+
+    if (!TestVulkanInstance::synchronization2 || !TestVulkanInstance::timelineSemaphore) {
+        fprintf(stderr, "synchronization2 or timelineSemaphore not available, skipping.\n");
+        return;
+    }
+
+    // Create a timeline semaphore and a binary semaphore.
+    vk::SemaphoreTypeCreateInfo timelineInfo {vk::SemaphoreType::eTimeline, 0};
+    vk::SemaphoreCreateInfo     semInfo {};
+    semInfo.setPNext(&timelineInfo);
+    auto timeline = gi->device.createSemaphoreUnique(semInfo, gi->allocator);
+    auto binary   = gi->device.createSemaphoreUnique({}, gi->allocator);
+
+    // Submit some work that signals the timeline point.
+    CommandQueue::SyncPoint signalPt {timeline.get(), 1, vk::PipelineStageFlagBits::eAllCommands};
+    auto                    c1 = q.begin("work");
+    q.submit2({c1, {}, {}, {}, {}, {1, &signalPt}});
+
+    // Bridge-only: wait on timeline point, signal binary — no command buffer.
+    CommandQueue::SyncPoint waitPt    = {timeline.get(), 1, vk::PipelineStageFlagBits::eAllCommands};
+    CommandQueue::SyncPoint signalBin = {binary.get(), 0, vk::PipelineStageFlagBits::eAllCommands};
+    auto                    bridgeId  = q.submit2({{}, {}, {}, {1, &waitPt}, {1, &signalBin}});
+    CHECK(!bridgeId.empty()); // bridge submit must produce a trackable submission
+
+    // Consumer: wait on the binary semaphore to confirm the bridge actually ran.
+    CommandQueue::SyncPoint waitBin = {binary.get(), 0, vk::PipelineStageFlagBits::eAllCommands};
+    auto                    c2      = q.begin("consumer");
+    q.submit2({c2, {}, {1, &waitBin}});
+
+    q.waitIdle();
+    CHECK(true); // reaching here without a hang confirms the bridge semaphore was signaled
+}
+
 /// Verify submit2 handles timeline semaphore signal + wait via VkSubmitInfo2.
 TEST_CASE("queue-submit2-timeline-semaphore") {
     using namespace rapid_vulkan;

--- a/dev/test/test-instance.h
+++ b/dev/test/test-instance.h
@@ -6,6 +6,8 @@
 struct TestVulkanInstance {
     inline static std::unique_ptr<rapid_vulkan::Instance> instance;
     inline static std::unique_ptr<rapid_vulkan::Device>   device;
+    inline static bool                                    synchronization2 = false; ///< true if VK_KHR_synchronization2 / VK 1.3 was enabled at device creation
+    inline static bool timelineSemaphore = false; ///< true if VK_KHR_timeline_semaphore / VK 1.2 was enabled at device creation
 };
 
 struct ScopedTimer {

--- a/dev/test/test-main.cpp
+++ b/dev/test/test-main.cpp
@@ -41,7 +41,25 @@ struct TestVulkanInstanceImpl : public TestVulkanInstance {
         using namespace rapid_vulkan;
         auto icp = Instance::ConstructParameters {.validation = Instance::BREAK_ON_VK_ERROR, .backtrace = backtrace};
         instance = std::make_unique<Instance>(icp);
-        device   = std::make_unique<Device>(Device::ConstructParameters {*instance});
+
+        auto                               dcp = Device::ConstructParameters {*instance};
+        vk::PhysicalDeviceVulkan13Features feature13;
+        if (instance->cp().apiVersion >= VK_VERSION_1_3) {
+            // enable synchronization2 feature.
+            feature13.synchronization2 = true;
+            dcp.addFeature(feature13);
+        }
+        vk::PhysicalDeviceVulkan12Features feature12;
+        if (instance->cp().apiVersion >= VK_VERSION_1_2) {
+            // enable timeline semaphore feature.
+            feature12.timelineSemaphore = true;
+            dcp.addFeature(feature12);
+        }
+        device = std::make_unique<Device>(dcp);
+
+        // Record which optional features were actually requested so tests can skip paths that aren't available.
+        synchronization2  = (instance->cp().apiVersion >= VK_VERSION_1_3);
+        timelineSemaphore = (instance->cp().apiVersion >= VK_VERSION_1_2);
     }
 
     ~TestVulkanInstanceImpl() {

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -2894,14 +2894,80 @@ public:
             s->fence = s->builtInFence.get();
         }
 
-        // submit the command buffer
-        std::vector<vk::PipelineStageFlags> flags(sp.waitSemaphores.size(), vk::PipelineStageFlagBits::eBottomOfPipe);
-        vk::SubmitInfo                      si;
-        si.setWaitSemaphores(sp.waitSemaphores);
-        si.setSignalSemaphores(sp.signalSemaphores);
-        si.setCommandBuffers(handles);
-        si.setPWaitDstStageMask(flags.data());
-        _desc.handle.submit({si}, s->fence);
+        // SyncPoint.stages is vk::PipelineStageFlags (32-bit v1). The v2 path (VkSubmitInfo2)
+        // needs vk::PipelineStageFlags2 (64-bit). v1 and v2 flag bits are identical in the
+        // lower 32 bits by Vulkan spec design, so a plain zero-extending cast is correct.
+        auto toV2Stage = [](vk::PipelineStageFlags f) -> vk::PipelineStageFlags2 {
+            return vk::PipelineStageFlags2 {VkPipelineStageFlags2 {static_cast<uint32_t>(f)}};
+        };
+
+        if (!_desc.gi->synchronization2) {
+            // VkSubmitInfo + chained VkTimelineSemaphoreSubmitInfo (synchronization2 unavailable)
+            std::vector<vk::Semaphore>          waitSems;
+            std::vector<vk::PipelineStageFlags> waitStages;
+            std::vector<uint64_t>               waitValues;
+            waitSems.reserve(sp.waitBinaries.size() + sp.waitPoints.size());
+            waitStages.reserve(waitSems.capacity());
+            waitValues.reserve(waitSems.capacity());
+            for (const auto & e : sp.waitBinaries) {
+                waitSems.push_back(e.semaphore);
+                waitStages.push_back(e.stages); // already v1 (32-bit)
+                waitValues.push_back(0);        // driver ignores value for binary semaphores
+            }
+            for (const auto & e : sp.waitPoints) {
+                waitSems.push_back(e.semaphore);
+                waitStages.push_back(e.stages); // already v1 (32-bit)
+                waitValues.push_back(e.progress);
+            }
+
+            std::vector<vk::Semaphore> signalSems;
+            std::vector<uint64_t>      signalValues;
+            signalSems.reserve(sp.signalBinaries.size() + sp.signalPoints.size());
+            signalValues.reserve(signalSems.capacity());
+            for (const auto & e : sp.signalBinaries) {
+                signalSems.push_back(e.semaphore);
+                signalValues.push_back(0);
+            }
+            for (const auto & e : sp.signalPoints) {
+                signalSems.push_back(e.semaphore);
+                signalValues.push_back(e.progress);
+            }
+
+            vk::SubmitInfo si;
+            si.setWaitSemaphores(waitSems);
+            si.setSignalSemaphores(signalSems);
+            si.setCommandBuffers(handles);
+            if (!waitSems.empty()) si.setPWaitDstStageMask(waitStages.data());
+
+            // Chain VkTimelineSemaphoreSubmitInfo only when timeline semaphores are involved.
+            vk::TimelineSemaphoreSubmitInfo timelineInfo;
+            if (!sp.waitPoints.empty() || !sp.signalPoints.empty()) {
+                timelineInfo.setWaitSemaphoreValues(waitValues);
+                timelineInfo.setSignalSemaphoreValues(signalValues);
+                si.setPNext(&timelineInfo);
+            }
+
+            _desc.handle.submit({si}, s->fence);
+        } else {
+            // VkSubmitInfo2: native PipelineStageFlags2 and timeline values (synchronization2 available).
+            std::vector<vk::SemaphoreSubmitInfo> waitSems;
+            waitSems.reserve(sp.waitBinaries.size() + sp.waitPoints.size());
+            for (const auto & e : sp.waitBinaries) waitSems.push_back({e.semaphore, 0, toV2Stage(e.stages)});
+            for (const auto & e : sp.waitPoints) waitSems.push_back({e.semaphore, e.progress, toV2Stage(e.stages)});
+
+            std::vector<vk::SemaphoreSubmitInfo> signalSems;
+            signalSems.reserve(sp.signalBinaries.size() + sp.signalPoints.size());
+            for (const auto & e : sp.signalBinaries) signalSems.push_back({e.semaphore, 0, toV2Stage(e.stages)});
+            for (const auto & e : sp.signalPoints) signalSems.push_back({e.semaphore, e.progress, toV2Stage(e.stages)});
+
+            std::vector<vk::CommandBufferSubmitInfo> cbInfos;
+            cbInfos.reserve(handles.size());
+            for (auto h : handles) cbInfos.push_back({h});
+
+            vk::SubmitInfo2 si2;
+            si2.setWaitSemaphoreInfos(waitSems).setCommandBufferInfos(cbInfos).setSignalSemaphoreInfos(signalSems);
+            _desc.handle.submit2({si2}, s->fence);
+        }
 
         // Mark the command buffers as pending. remove them from the active list.
         for (auto cb : s->commandBuffers) {
@@ -3266,7 +3332,12 @@ public:
         }
         // Keep the image's tracked state in sync with the GPU layout after the transition.
         bb.image->setState(DESIRED_PRESENT_STATUS, Image::FULL_RANGE);
-        frame.frameEndSubmission = _graphicsQueue->submit({cb, {}, pp.renderFinished, {bb.frameEndSemaphore}});
+        // Convert binary semaphores to SyncPoints; pp.renderFinished is still typed as ArrayProxy<Semaphore>.
+        std::vector<CommandQueue::SyncPoint> waitSps;
+        waitSps.reserve(pp.renderFinished.size());
+        for (auto s : pp.renderFinished) waitSps.push_back({s});
+        CommandQueue::SyncPoint endSp {bb.frameEndSemaphore};
+        frame.frameEndSubmission = _graphicsQueue->submit({cb, {}, waitSps, {}, {1, &endSp}});
 
         PresentResult pr;
         pr.status = PresentResult::SUCCESS;
@@ -3292,8 +3363,10 @@ public:
             }
         } else {
             // For headless swapchain, we do a dummy submit to signal the image available semaphore.
-            auto dummySwap           = _graphicsQueue->begin("headless dummy swap");
-            frame.frameEndSubmission = _graphicsQueue->submit({dummySwap, {}, {bb.frameEndSemaphore}, {frame.imageAvailable}});
+            auto                    dummySwap = _graphicsQueue->begin("headless dummy swap");
+            CommandQueue::SyncPoint waitSp2 {bb.frameEndSemaphore};
+            CommandQueue::SyncPoint iaSp {frame.imageAvailable};
+            frame.frameEndSubmission = _graphicsQueue->submit({dummySwap, {}, {1, &waitSp2}, {}, {1, &iaSp}});
         }
 
         // Move to the next frame.
@@ -3489,8 +3562,9 @@ private:
             setVkHandleName(_cp.gi->device, frame.imageAvailable, format("image available semaphore for headless frame %zu", i));
 
             // then signal it.
-            auto cb = _graphicsQueue->begin(format("dummy submit to signal image available semaphore for headless frame %zu", i).c_str());
-            _graphicsQueue->submit({cb, {}, {}, {frame.imageAvailable}});
+            auto                    cb = _graphicsQueue->begin(format("dummy submit to signal image available semaphore for headless frame %zu", i).c_str());
+            CommandQueue::SyncPoint iaSp2 {frame.imageAvailable};
+            _graphicsQueue->submit({cb, {}, {}, {}, {1, &iaSp2}});
         }
 
         recreateHeadlessSwapchain();
@@ -4071,7 +4145,53 @@ Device::Device(const ConstructParameters & cp): _cp(cp) {
 
     // make sure all extensions are actually supported by the hardware.
     auto availableDeviceExtensions = enumerateDeviceExtensions(_gi.physical);
-    auto enabledDeviceExtensions   = validateExtensions(availableDeviceExtensions, askedDeviceExtensions);
+
+    // Detect synchronization2 support: either Vulkan 1.3 core (where it is a required feature)
+    // or the VK_KHR_synchronization2 extension on pre-1.3 devices.
+    if (_gi.apiVersion >= vk::ApiVersion13) {
+        // Promoted to required core feature in 1.3; vkQueueSubmit2 is always available.
+        vk::PhysicalDeviceSynchronization2FeaturesKHR sync2 {};
+        sync2.synchronization2 = VK_TRUE;
+        deviceFeatures.addFeature(sync2);
+        _gi.synchronization2                                           = true;
+        askedDeviceExtensions[VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME] = true; // required.
+    } else {
+        // Enable the KHR extension if available; also enable the corresponding feature bit.
+        auto extIt = std::find_if(availableDeviceExtensions.begin(), availableDeviceExtensions.end(), [](const vk::ExtensionProperties & e) {
+            return std::string_view(e.extensionName) == VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME;
+        });
+        if (extIt != availableDeviceExtensions.end()) {
+            askedDeviceExtensions[VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME] = false; // optional
+            vk::PhysicalDeviceSynchronization2FeaturesKHR sync2 {};
+            sync2.synchronization2 = VK_TRUE;
+            deviceFeatures.addFeature(sync2);
+            _gi.synchronization2 = true;
+        }
+    }
+
+    // Detect timeline semaphore support: Vulkan 1.2 core (required feature) or
+    // VK_KHR_timeline_semaphore extension on pre-1.2 devices.
+    if (_gi.apiVersion >= vk::ApiVersion12) {
+        // Promoted to required core feature in 1.2; always available.
+        vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR tsf {};
+        tsf.timelineSemaphore = VK_TRUE;
+        deviceFeatures.addFeature(tsf);
+        askedDeviceExtensions[VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME] = true; // required
+        _gi.timelineSemaphore                                           = true;
+    } else {
+        auto extIt = std::find_if(availableDeviceExtensions.begin(), availableDeviceExtensions.end(), [](const vk::ExtensionProperties & e) {
+            return std::string_view(e.extensionName) == VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME;
+        });
+        if (extIt != availableDeviceExtensions.end()) {
+            askedDeviceExtensions[VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME] = false; // optional
+            vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR tsf {};
+            tsf.timelineSemaphore = VK_TRUE;
+            deviceFeatures.addFeature(tsf);
+            _gi.timelineSemaphore = true;
+        }
+    }
+
+    auto enabledDeviceExtensions = validateExtensions(availableDeviceExtensions, askedDeviceExtensions);
 
     // create device, one queue for each family
     float                                  queuePriority = 1.0f;

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -2883,7 +2883,12 @@ public:
             s->commandBuffers.push_back(p);
             handles.push_back(p->handle());
         }
-        if (s->commandBuffers.empty()) return {};
+        // A bridge-only submission (no command buffers, but with semaphore operations) is
+        // valid and intentional: it lets a timeline sync point be waited on while signaling
+        // a binary semaphore, which is required when bridging to vkQueuePresentKHR (which
+        // only accepts binary semaphores). Reject only when there is truly nothing to do.
+        bool hasSemaphoreWork = !sp.waitBinaries.empty() || !sp.waitPoints.empty() || !sp.signalBinaries.empty() || !sp.signalPoints.empty();
+        if (s->commandBuffers.empty() && !hasSemaphoreWork) return {};
 
         // set submission index
         s->index = ++_nextSubmissionId;

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -331,7 +331,7 @@ public:
             CmdDebugLabel label(cb, ("set buffer content of " + _owner.name()).c_str());
             staging.cmdCopy({cb, _owner.handle(), _desc.size, dstOffset, 0, size});
             label.end();
-            queue.wait(queue.submit({{cb}}));
+            queue.wait(queue.submit1({{cb}}));
         }
     }
 
@@ -362,7 +362,7 @@ public:
 
         // copy data from the source buffer to the staging buffer. wait for it to complete.
         cmdCopy({cb, staging.handle(), size, 0, offset});
-        queue.wait(queue.submit({cb}));
+        queue.wait(queue.submit1({cb}));
 
         // read data from the staging buffer
         auto m = Map<uint8_t>(staging);
@@ -921,7 +921,7 @@ public:
             .cmdWrite(c);
         c.handle().copyBufferToImage(staging, _desc.handle, vk::ImageLayout::eTransferDstOptimal, {copyRegion});
         label.end();
-        q.wait(q.submit({{c}}));
+        q.wait(q.submit1({{c}}));
 
         // Update per-plane state to reflect the transfer destination layout.
         forEachAspectBit(_state.validAspects,
@@ -980,7 +980,7 @@ public:
                    vk::ImageLayout::eTransferSrcOptimal, r)
                 .cmdWrite(c);
             c.handle().copyImageToBuffer(_desc.handle, vk::ImageLayout::eTransferSrcOptimal, staging, copyRegions);
-            q.wait(q.submit({c}));
+            q.wait(q.submit1({c}));
         }
 
         // read data out of the staging buffer
@@ -2866,7 +2866,10 @@ public:
         return cb;
     }
 
-    SubmissionID submit(const SubmitParameters & sp) {
+    SubmissionID submit1(const SubmitParameters & sp) { return submitImpl(sp, false); }
+    SubmissionID submit2(const SubmitParameters & sp) { return submitImpl(sp, true); }
+
+    SubmissionID submitImpl(const SubmitParameters & sp, bool useV2) {
         // remove duplicated command buffers
         auto uniqueCommandBuffers = unique(sp.commandBuffers);
 
@@ -2901,8 +2904,8 @@ public:
             return vk::PipelineStageFlags2 {VkPipelineStageFlags2 {static_cast<uint32_t>(f)}};
         };
 
-        if (!_desc.gi->synchronization2) {
-            // VkSubmitInfo + chained VkTimelineSemaphoreSubmitInfo (synchronization2 unavailable)
+        if (!useV2) {
+            // VkSubmitInfo + optional VkTimelineSemaphoreSubmitInfo pNext chain
             std::vector<vk::Semaphore>          waitSems;
             std::vector<vk::PipelineStageFlags> waitStages;
             std::vector<uint64_t>               waitValues;
@@ -2967,7 +2970,7 @@ public:
             vk::SubmitInfo2 si2;
             si2.setWaitSemaphoreInfos(waitSems).setCommandBufferInfos(cbInfos).setSignalSemaphoreInfos(signalSems);
             _desc.handle.submit2({si2}, s->fence);
-        }
+        } // end if (!useV2)
 
         // Mark the command buffers as pending. remove them from the active list.
         for (auto cb : s->commandBuffers) {
@@ -3181,7 +3184,8 @@ CommandQueue::~CommandQueue() {
 }
 auto CommandQueue::desc() const -> const Desc & { return _impl->desc(); }
 auto CommandQueue::begin(const char * purpose, vk::CommandBufferLevel level) -> CommandBuffer { return _impl->begin(purpose, level); }
-auto CommandQueue::submit(const SubmitParameters & sp) -> SubmissionID { return _impl->submit(sp); }
+auto CommandQueue::submit1(const SubmitParameters & sp) -> SubmissionID { return _impl->submit1(sp); }
+auto CommandQueue::submit2(const SubmitParameters & sp) -> SubmissionID { return _impl->submit2(sp); }
 void CommandQueue::drop(vk::ArrayProxy<const CommandBuffer> commandBuffers) { _impl->drop(commandBuffers); }
 auto CommandQueue::wait(const vk::ArrayProxy<const SubmissionID> & s) -> CommandQueue & { return _impl->wait(s); }
 auto CommandQueue::waitIdle() -> CommandQueue & { return _impl->waitIdle(); }
@@ -3337,7 +3341,7 @@ public:
         waitSps.reserve(pp.renderFinished.size());
         for (auto s : pp.renderFinished) waitSps.push_back({s});
         CommandQueue::SyncPoint endSp {bb.frameEndSemaphore};
-        frame.frameEndSubmission = _graphicsQueue->submit({cb, {}, waitSps, {}, {1, &endSp}});
+        frame.frameEndSubmission = _graphicsQueue->submit1({cb, {}, waitSps, {}, {1, &endSp}});
 
         PresentResult pr;
         pr.status = PresentResult::SUCCESS;
@@ -3366,7 +3370,7 @@ public:
             auto                    dummySwap = _graphicsQueue->begin("headless dummy swap");
             CommandQueue::SyncPoint waitSp2 {bb.frameEndSemaphore};
             CommandQueue::SyncPoint iaSp {frame.imageAvailable};
-            frame.frameEndSubmission = _graphicsQueue->submit({dummySwap, {}, {1, &waitSp2}, {}, {1, &iaSp}});
+            frame.frameEndSubmission = _graphicsQueue->submit1({dummySwap, {}, {1, &waitSp2}, {}, {1, &iaSp}});
         }
 
         // Move to the next frame.
@@ -3564,7 +3568,7 @@ private:
             // then signal it.
             auto                    cb = _graphicsQueue->begin(format("dummy submit to signal image available semaphore for headless frame %zu", i).c_str());
             CommandQueue::SyncPoint iaSp2 {frame.imageAvailable};
-            _graphicsQueue->submit({cb, {}, {}, {}, {1, &iaSp2}});
+            _graphicsQueue->submit1({cb, {}, {}, {}, {1, &iaSp2}});
         }
 
         recreateHeadlessSwapchain();
@@ -3713,7 +3717,7 @@ private:
         }
 
         // execute the command buffer to update image layout
-        _graphicsQueue->submit({c}).wait();
+        _graphicsQueue->submit1({c}).wait();
     }
 
     void recreateHeadlessSwapchain() {
@@ -3775,7 +3779,7 @@ private:
         }
 
         // execute the command buffer to update image layout
-        _graphicsQueue->submit({c});
+        _graphicsQueue->submit1({c});
         _graphicsQueue->waitIdle();
     }
 };
@@ -4146,50 +4150,50 @@ Device::Device(const ConstructParameters & cp): _cp(cp) {
     // make sure all extensions are actually supported by the hardware.
     auto availableDeviceExtensions = enumerateDeviceExtensions(_gi.physical);
 
-    // Detect synchronization2 support: either Vulkan 1.3 core (where it is a required feature)
-    // or the VK_KHR_synchronization2 extension on pre-1.3 devices.
-    if (_gi.apiVersion >= vk::ApiVersion13) {
-        // Promoted to required core feature in 1.3; vkQueueSubmit2 is always available.
-        vk::PhysicalDeviceSynchronization2FeaturesKHR sync2 {};
-        sync2.synchronization2 = VK_TRUE;
-        deviceFeatures.addFeature(sync2);
-        _gi.synchronization2                                           = true;
-        askedDeviceExtensions[VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME] = true; // required.
-    } else {
-        // Enable the KHR extension if available; also enable the corresponding feature bit.
-        auto extIt = std::find_if(availableDeviceExtensions.begin(), availableDeviceExtensions.end(), [](const vk::ExtensionProperties & e) {
-            return std::string_view(e.extensionName) == VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME;
-        });
-        if (extIt != availableDeviceExtensions.end()) {
-            askedDeviceExtensions[VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME] = false; // optional
-            vk::PhysicalDeviceSynchronization2FeaturesKHR sync2 {};
-            sync2.synchronization2 = VK_TRUE;
-            deviceFeatures.addFeature(sync2);
-            _gi.synchronization2 = true;
-        }
-    }
+    // // Detect synchronization2 support: either Vulkan 1.3 core (where it is a required feature)
+    // // or the VK_KHR_synchronization2 extension on pre-1.3 devices.
+    // if (_gi.apiVersion >= vk::ApiVersion13) {
+    //     // Promoted to required core feature in 1.3; vkQueueSubmit2 is always available.
+    //     vk::PhysicalDeviceSynchronization2FeaturesKHR sync2 {};
+    //     sync2.synchronization2 = VK_TRUE;
+    //     deviceFeatures.addFeature(sync2);
+    //     _gi.synchronization2                                           = true;
+    //     askedDeviceExtensions[VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME] = true; // required.
+    // } else {
+    //     // Enable the KHR extension if available; also enable the corresponding feature bit.
+    //     auto extIt = std::find_if(availableDeviceExtensions.begin(), availableDeviceExtensions.end(), [](const vk::ExtensionProperties & e) {
+    //         return std::string_view(e.extensionName) == VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME;
+    //     });
+    //     if (extIt != availableDeviceExtensions.end()) {
+    //         askedDeviceExtensions[VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME] = false; // optional
+    //         vk::PhysicalDeviceSynchronization2FeaturesKHR sync2 {};
+    //         sync2.synchronization2 = VK_TRUE;
+    //         deviceFeatures.addFeature(sync2);
+    //         _gi.synchronization2 = true;
+    //     }
+    // }
 
-    // Detect timeline semaphore support: Vulkan 1.2 core (required feature) or
-    // VK_KHR_timeline_semaphore extension on pre-1.2 devices.
-    if (_gi.apiVersion >= vk::ApiVersion12) {
-        // Promoted to required core feature in 1.2; always available.
-        vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR tsf {};
-        tsf.timelineSemaphore = VK_TRUE;
-        deviceFeatures.addFeature(tsf);
-        askedDeviceExtensions[VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME] = true; // required
-        _gi.timelineSemaphore                                           = true;
-    } else {
-        auto extIt = std::find_if(availableDeviceExtensions.begin(), availableDeviceExtensions.end(), [](const vk::ExtensionProperties & e) {
-            return std::string_view(e.extensionName) == VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME;
-        });
-        if (extIt != availableDeviceExtensions.end()) {
-            askedDeviceExtensions[VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME] = false; // optional
-            vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR tsf {};
-            tsf.timelineSemaphore = VK_TRUE;
-            deviceFeatures.addFeature(tsf);
-            _gi.timelineSemaphore = true;
-        }
-    }
+    // // Detect timeline semaphore support: Vulkan 1.2 core (required feature) or
+    // // VK_KHR_timeline_semaphore extension on pre-1.2 devices.
+    // if (_gi.apiVersion >= vk::ApiVersion12) {
+    //     // Promoted to required core feature in 1.2; always available.
+    //     vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR tsf {};
+    //     tsf.timelineSemaphore = VK_TRUE;
+    //     deviceFeatures.addFeature(tsf);
+    //     askedDeviceExtensions[VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME] = true; // required
+    //     _gi.timelineSemaphore                                           = true;
+    // } else {
+    //     auto extIt = std::find_if(availableDeviceExtensions.begin(), availableDeviceExtensions.end(), [](const vk::ExtensionProperties & e) {
+    //         return std::string_view(e.extensionName) == VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME;
+    //     });
+    //     if (extIt != availableDeviceExtensions.end()) {
+    //         askedDeviceExtensions[VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME] = false; // optional
+    //         vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR tsf {};
+    //         tsf.timelineSemaphore = VK_TRUE;
+    //         deviceFeatures.addFeature(tsf);
+    //         _gi.timelineSemaphore = true;
+    //     }
+    // }
 
     auto enabledDeviceExtensions = validateExtensions(availableDeviceExtensions, askedDeviceExtensions);
 

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -3893,6 +3893,7 @@ static void printPhysicalDeviceInfo(const std::vector<vk::PhysicalDevice> & avai
            << PRINT_LIMIT(maxPerStageDescriptorStorageImages)
            << PRINT_LIMIT(maxPerStageDescriptorInputAttachments)
            << PRINT_LIMIT(maxPerStageResources)
+           << PRINT_LIMIT(maxPushConstantsSize)
            << PRINT_LIMIT(maxDescriptorSetSamplers)
            << PRINT_LIMIT(maxDescriptorSetUniformBuffers)
            << PRINT_LIMIT(maxDescriptorSetUniformBuffersDynamic)

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -1101,7 +1101,7 @@ private:
         auto   it = sr.planes.find(aspect);
         if (it == sr.planes.end()) return; // not a valid plane for this format
         if (it->second == newState) return;
-        RVI_LOGV("image '%s': mip=%u layer=%u aspect=0x%x layout %d->%d", _owner.name().c_str(), mip, arrayLayer, static_cast<uint32_t>(aspect),
+        RVI_LOGD("image '%s': mip=%u layer=%u aspect=0x%x layout %d->%d", _owner.name().c_str(), mip, arrayLayer, static_cast<uint32_t>(aspect),
                  static_cast<int>(it->second.layout), static_cast<int>(newState.layout));
         it->second = newState;
     }

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -2585,8 +2585,13 @@ public:
         return _gi->device.allocateDescriptorSets({_pool, 1, &_layout})[0];
     }
 
-    /// Release all already-full descriptor pools.
-    void purge() {
+    /// Reset the pool to intial state, release all allocated sets.
+    void reset() {
+        if (_pool) {
+            _gi->device.resetDescriptorPool(_pool);
+            _availableSets = _maxSets;
+        }
+        // Release all already-full descriptor pools.
         for (auto & p : _full) { _gi->safeDestroy(p); }
         _full.clear();
     }
@@ -2772,7 +2777,7 @@ private:
         auto gi = _queue.desc().gi;
         gi->safeDestroy(_handle, _pool);
         gi->device.resetCommandPool(_pool);
-        for (auto & p : _descriptorPools) p.second.purge();
+        for (auto & p : _descriptorPools) p.second.reset();
         _last = {};
         _pipelines.clear();
         _buffers.clear();

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -1732,7 +1732,8 @@ GraphicsPipeline::GraphicsPipeline(const ConstructParameters & params): Pipeline
 
     // setup vertex input stage
     const auto & refl = _impl->layout().reflection();
-    if (refl.vertex.size() != params.va.size()) {
+    // param.va might contains attributes that is not used by shader, which is fine.
+    if (refl.vertex.size() > params.va.size()) {
         RVI_LOGE("Failed to create graphics pipeline (%s): vertex input stage requires %zu attributes, but only %zu are provided.", params.name.c_str(),
                  refl.vertex.size(), params.va.size());
         return;
@@ -2805,7 +2806,9 @@ private:
         for (const auto & buf : pack.dependencies.buffers) _buffers.insert(buf);
         for (const auto & img : pack.dependencies.images) _images.insert(img);
         for (const auto & smp : pack.dependencies.samplers) _samplers.insert(smp);
-        for (const auto & vb : pack.vertexBuffers) { if (vb) _buffers.insert(vb); }
+        for (const auto & vb : pack.vertexBuffers) {
+            if (vb) _buffers.insert(vb);
+        }
         if (pack.indexBuffer) _buffers.insert(pack.indexBuffer);
     }
 };

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -2757,6 +2757,8 @@ private:
     DescriptorPoolMap      _descriptorPools;
     Ref<const DrawPack>    _last;
 
+    // resources referneced by draw/dispatch commands recorded in this command buffer. We need to keep references to
+    // them to ensure their lifetime covers the execution of this command buffer on the GPU.
     std::set<Ref<const Pipeline>> _pipelines;
     std::set<Ref<const Buffer>>   _buffers;
     std::set<Ref<const Image>>    _images;
@@ -2795,9 +2797,16 @@ private:
         return iter->second.allocate();
     }
 
-    void updateResourceReferenceList(const DrawPack &) {
-        //
-        // RVI_ASSERT(false, "not implemented yet.");
+    void updateResourceReferenceList(const DrawPack & pack) {
+        // Keep every resource the draw pack references alive for the lifetime of this command buffer.
+        // Vulkan requires that all objects bound via vkCmd* remain valid until the command buffer
+        // finishes executing on the GPU; clear() releases these refs when the buffer is retired.
+        if (pack.pipeline) _pipelines.insert(pack.pipeline);
+        for (const auto & buf : pack.dependencies.buffers) _buffers.insert(buf);
+        for (const auto & img : pack.dependencies.images) _images.insert(img);
+        for (const auto & smp : pack.dependencies.samplers) _samplers.insert(smp);
+        for (const auto & vb : pack.vertexBuffers) { if (vb) _buffers.insert(vb); }
+        if (pack.indexBuffer) _buffers.insert(pack.indexBuffer);
     }
 };
 

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -808,22 +808,14 @@ public:
             cp.info.flags &= ~vk::ImageCreateFlagBits::eCubeCompatible;
         }
 
-        // // create a default image view that covers the whole image
-        // auto aspect          = determineImageAspect(ci.aspect, ci.format);
-        // auto vci             = VkImageViewCreateInfo {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
-        // vci.image            = image;
-        // vci.viewType         = ci.isCube() ? VK_IMAGE_VIEW_TYPE_CUBE : ci.arrayLayers > 1 ? VK_IMAGE_VIEW_TYPE_2D_ARRAY : VK_IMAGE_VIEW_TYPE_2D;
-        // vci.format           = ci.format;
-        // vci.components       = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
-        // vci.subresourceRange = {aspect, 0, ci.mipLevels, 0, ci.arrayLayers};
-        // RVI_VK_REQUIRE(vkCreateImageView(g.device, &vci, g.allocator, &view));
-        // setVkHandleName(g.device, view, name);
+        initState(State::PlaneState::UNDEFINED());
     }
 
     Impl(Image & o, const ImportParameters & ip): _owner(o), _gi(ip.gi) {
         RVI_REQUIRE(ip.gi);
         RVI_REQUIRE(ip.desc.handle);
         _desc = ip.desc;
+        initState(State::PlaneState::UNDEFINED());
     }
 
     ~Impl() {
@@ -843,17 +835,22 @@ public:
         }
     }
 
-    const Desc & desc() const { return _desc; }
+    const Desc &  desc() const { return _desc; }
+    const State & state() const { return _state; }
 
     vk::ImageView getView(GetViewParameters p) const {
         if (p.format == vk::Format::eUndefined) p.format = _desc.format;
-        p.range.aspectMask = determineImageAspect(p.format, p.range.aspectMask);
+        p.range.aspectMask &= _state.validAspects;
+        if (!p.range.aspectMask) RVI_UNLIKELY {
+                RVI_LOGE("Image::getView: subresource aspect mask is not valid for this image");
+                return {};
+            }
         clampRange(p.range.baseMipLevel, p.range.levelCount, _desc.mipLevels);
         clampRange(p.range.baseArrayLayer, p.range.layerCount, _desc.arrayLayers);
-        if (0 == p.range.layerCount || 0 == p.range.levelCount) {
-            RVI_LOGE("Image::getView: subresource range is out of bounds");
-            return {};
-        }
+        if (0 == p.range.layerCount || 0 == p.range.levelCount) RVI_UNLIKELY {
+                RVI_LOGE("Image::getView: subresource range is out of bounds");
+                return {};
+            }
         p.type = determineViewType(p.type, p.range);
         if ((int) p.type < 0) return {};
         auto & view = _views[p];
@@ -881,8 +878,6 @@ public:
             return false;
         }
 
-        // TODO: validate mip level and array layer.
-
         // adjust area to fit image size
         auto area = clampRect3D(params.area, mipExtent);
         if (area.w == 0 || area.h == 0 || area.d == 0) return false;
@@ -902,11 +897,10 @@ public:
         staging.unmap();
 
         // determine subresource aspect
-        auto aspect = determineImageAspect(_desc.format);
 
         // Setup buffer copy regions for the subresource
         auto copyRegion = vk::BufferImageCopy()
-                              .setImageSubresource({aspect, params.mipLevel, params.arrayLayer, 1})
+                              .setImageSubresource({_state.validAspects, params.mipLevel, params.arrayLayer, 1})
                               .setImageOffset({(int) area.x, (int) area.y, (int) area.z})
                               .setImageExtent({area.w, area.h, area.d});
 
@@ -919,7 +913,7 @@ public:
         }
 
         CmdDebugLabel label(c, ("set image content of " + _owner.name()).c_str());
-        auto          r = vk::ImageSubresourceRange(aspect, params.mipLevel, 1, params.arrayLayer, 1);
+        auto          r = vk::ImageSubresourceRange(_state.validAspects, params.mipLevel, 1, params.arrayLayer, 1);
         Barrier {}
             .s(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eTransfer)
             .i(_desc.handle, vk::AccessFlagBits::eMemoryWrite | vk::AccessFlagBits::eShaderWrite, vk::AccessFlagBits::eTransferRead,
@@ -928,10 +922,14 @@ public:
         c.handle().copyBufferToImage(staging, _desc.handle, vk::ImageLayout::eTransferDstOptimal, {copyRegion});
         label.end();
         q.wait(q.submit({{c}}));
+
+        // Update per-plane state to reflect the transfer destination layout.
+        forEachAspectBit(_state.validAspects,
+                         [&](vk::ImageAspectFlagBits bit) { setStatePlane(params.mipLevel, params.arrayLayer, bit, State::PlaneState::TRANSFER_DST()); });
         return true;
     }
 
-    Content readContent(const ReadContentParameters & params) const {
+    Content readContent(const ReadContentParameters & params) {
         // uint32_t mipLevel   = params.mipLevel;
         // uint32_t levelCount = params.layerCount;
         // uint32_t arrayLayer = params.arrayLayer;
@@ -941,7 +939,6 @@ public:
         // if (0 == levelCount || 0 == layerCount) return {};
 
         auto formatDesc = VkFormatDesc::get(_desc.format);
-        auto aspect     = determineImageAspect(_desc.format);
         auto mipExtents = buildMipExtentArray();
 
         Content                          content;
@@ -956,7 +953,7 @@ public:
                                           .setBufferOffset(dataSize)
                                           .setBufferRowLength(extent.width)
                                           .setBufferImageHeight(extent.height)
-                                          .setImageSubresource({aspect, m, a, 1})
+                                          .setImageSubresource({_state.validAspects, m, a, 1})
                                           .setImageOffset({0, 0, 0})
                                           .setImageExtent(extent));
                 content.subresources.push_back({m, a, extent, rowPitch, dataSize});
@@ -967,14 +964,19 @@ public:
         // Allocate staging buffer
         auto staging = Buffer(Buffer::ConstructParameters {{_owner.name()}, _gi, dataSize}.setStaging());
 
+        // Derive current layout from internal state. readContent() blits the entire image with one
+        // barrier, so all subresources must already share the same layout; mip 0 / layer 0 is representative.
+        vk::ImageLayout currentLayout = vk::ImageLayout::eUndefined;
+        if (!_state.subresources.empty() && !_state.subresources[0].planes.empty()) { currentLayout = _state.subresources[0].planes.begin()->second.layout; }
+
         // Copy image content into the staging buffer
         auto q = CommandQueue({{_owner.name()}, _gi, params.queueFamily, params.queueIndex});
         auto c = q.begin(_owner.name().data());
         if (c) {
-            auto r = vk::ImageSubresourceRange(aspect, 0, _desc.mipLevels, 0, _desc.arrayLayers);
+            auto r = vk::ImageSubresourceRange(_state.validAspects, 0, _desc.mipLevels, 0, _desc.arrayLayers);
             Barrier {}
                 .s(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eTransfer)
-                .i(_desc.handle, vk::AccessFlagBits::eMemoryWrite | vk::AccessFlagBits::eShaderWrite, vk::AccessFlagBits::eTransferRead, params.currentLayout,
+                .i(_desc.handle, vk::AccessFlagBits::eMemoryWrite | vk::AccessFlagBits::eShaderWrite, vk::AccessFlagBits::eTransferRead, currentLayout,
                    vk::ImageLayout::eTransferSrcOptimal, r)
                 .cmdWrite(c);
             c.handle().copyImageToBuffer(_desc.handle, vk::ImageLayout::eTransferSrcOptimal, staging, copyRegions);
@@ -986,7 +988,9 @@ public:
         RVI_ASSERT(mapped.size == dataSize);
         content.storage.assign(mapped.data, mapped.data + mapped.size);
 
-        // done
+        // Update internal state: entire image is now in transfer-src layout.
+        setState(State::PlaneState::TRANSFER_SRC(), vk::ImageSubresourceRange(_state.validAspects, 0, _desc.mipLevels, 0, _desc.arrayLayers));
+
         content.format = _desc.format;
         return content;
     }
@@ -1023,8 +1027,85 @@ private:
     vk::DeviceMemory   _memory {};
     VmaAllocation      _allocation {};
     mutable ViewMap    _views;
+    State              _state;
+
+public:
+    bool validateSubresourceRange(vk::ImageSubresourceRange & range) const {
+        clampRange(range.baseMipLevel, range.levelCount, _state.numMips);
+        clampRange(range.baseArrayLayer, range.layerCount, _state.numLayers);
+        if (0 == range.levelCount || 0 == range.layerCount) return false;
+        range.aspectMask &= _state.validAspects;
+        return !!range.aspectMask;
+    }
+
+    // Update all planes in range; called by Image::setState().
+    void setState(const State::PlaneState & newState, const vk::ImageSubresourceRange & range) {
+        auto validateRange = range;
+        if (!validateSubresourceRange(validateRange)) return;
+        for (uint32_t i = validateRange.baseMipLevel; i < validateRange.baseMipLevel + validateRange.levelCount; ++i)
+            for (uint32_t j = validateRange.baseArrayLayer; j < validateRange.baseArrayLayer + validateRange.layerCount; ++j)
+                forEachAspectBit(validateRange.aspectMask, [&](vk::ImageAspectFlagBits bit) { setStatePlane(i, j, bit, newState); });
+    }
 
 private:
+    vk::ImageAspectFlags determineAvailableImageAspects(vk::Format format) {
+        switch (format) {
+        // depth only format
+        case vk::Format::eD16Unorm:
+        case vk::Format::eD32Sfloat:
+        case vk::Format::eX8D24UnormPack32:
+            return vk::ImageAspectFlagBits::eDepth;
+
+        // stencil only format
+        case vk::Format::eS8Uint:
+            return vk::ImageAspectFlagBits::eStencil;
+
+        // depth + stencil format
+        case vk::Format::eD16UnormS8Uint:
+        case vk::Format::eD24UnormS8Uint:
+        case vk::Format::eD32SfloatS8Uint:
+            return vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
+
+        // TODO: multi-planar formats
+
+        // default format
+        default:
+            return vk::ImageAspectFlagBits::eColor;
+        }
+    }
+
+    // Iterate each set bit in aspects, calling fn(vk::ImageAspectFlagBits). The m & -m
+    // idiom isolates the lowest set bit without a hard-coded aspect list.
+    template<typename Fn>
+    static void forEachAspectBit(vk::ImageAspectFlags aspects, Fn && fn) {
+        auto remaining = static_cast<vk::ImageAspectFlags::MaskType>(aspects);
+        while (remaining) {
+            auto lowBit = remaining & (~remaining + 1u);
+            fn(static_cast<vk::ImageAspectFlagBits>(lowBit));
+            remaining ^= lowBit;
+        }
+    }
+
+    // Initialize state storage from the image's format and dimensions. Called once from constructors.
+    void initState(const State::PlaneState & initial) {
+        _state.validAspects = determineAvailableImageAspects(_desc.format);
+        _state.numMips      = _desc.mipLevels;
+        _state.numLayers    = _desc.arrayLayers;
+        _state.subresources.assign((size_t) _desc.mipLevels * (size_t) _desc.arrayLayers, State::SubresourceState {});
+        for (auto & sr : _state.subresources) forEachAspectBit(_state.validAspects, [&](vk::ImageAspectFlagBits bit) { sr.planes.emplace(bit, initial); });
+    }
+
+    // Update a single plane; logs the layout transition at verbose level.
+    void setStatePlane(uint32_t mip, uint32_t arrayLayer, vk::ImageAspectFlagBits aspect, const State::PlaneState & newState) {
+        auto & sr = _state.subresources[_state.subresourceIndex(mip, arrayLayer)];
+        auto   it = sr.planes.find(aspect);
+        if (it == sr.planes.end()) return; // not a valid plane for this format
+        if (it->second == newState) return;
+        RVI_LOGV("image '%s': mip=%u layer=%u aspect=0x%x layout %d->%d", _owner.name().c_str(), mip, arrayLayer, static_cast<uint32_t>(aspect),
+                 static_cast<int>(it->second.layout), static_cast<int>(newState.layout));
+        it->second = newState;
+    }
+
     vk::ImageViewType determineViewType(vk::ImageViewType candidate, const vk::ImageSubresourceRange & range) const {
         if (vk::ImageViewType::e1D <= candidate && candidate <= vk::ImageViewType::eCubeArray) return candidate;
         switch (_desc.type) {
@@ -1090,34 +1171,7 @@ Image::ReadContentParameters & Image::ReadContentParameters::setQueue(const Comm
     queueIndex  = queue.index();
     return *this;
 }
-vk::ImageAspectFlags Image::determineImageAspect(vk::Format format, vk::ImageAspectFlags aspect) {
-    switch (format) {
-    // depth only format
-    case vk::Format::eD16Unorm:
-    case vk::Format::eD32Sfloat:
-    case vk::Format::eX8D24UnormPack32:
-        return vk::ImageAspectFlagBits::eDepth;
 
-    // stencil only format
-    case vk::Format::eS8Uint:
-        return vk::ImageAspectFlagBits::eStencil;
-
-    // depth + stencil format
-    case vk::Format::eD16UnormS8Uint:
-    case vk::Format::eD24UnormS8Uint:
-    case vk::Format::eD32SfloatS8Uint:
-        if (vk::ImageAspectFlagBits::eDepth == aspect || vk::ImageAspectFlagBits::eStencil == aspect)
-            return aspect;
-        else
-            return vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
-
-    // TODO: multi-planar formats
-
-    // default format
-    default:
-        return vk::ImageAspectFlagBits::eColor;
-    }
-}
 Image::Image(const ConstructParameters & cp): Root(cp) { _impl = new Impl(*this, cp); }
 Image::Image(const ImportParameters & cp): Root(cp) { _impl = new Impl(*this, cp); }
 Image::~Image() {
@@ -1127,7 +1181,9 @@ Image::~Image() {
 auto Image::desc() const -> const Desc & { return _impl->desc(); }
 auto Image::getView(const GetViewParameters & p) const -> vk::ImageView { return _impl->getView(p); }
 bool Image::setContent(const SetContentParameters & p) { return _impl->setContent(p); }
-auto Image::readContent(const ReadContentParameters & p) const -> Content { return _impl->readContent(p); }
+auto Image::readContent(const ReadContentParameters & p) -> Content { return _impl->readContent(p); }
+auto Image::getState() const -> const State & { return _impl->state(); }
+void Image::setState(const State::PlaneState & newState, const vk::ImageSubresourceRange & range) { _impl->setState(newState, range); }
 void Image::onNameChanged(const std::string &) { _impl->onNameChanged(); }
 // *********************************************************************************************************************
 // Shader
@@ -3109,7 +3165,7 @@ public:
         _renderPass->cmdBegin(cb, vk::RenderPassBeginInfo {{}, bb.framebuffer, vk::Rect2D({0, 0}, {extent.width, extent.height})}.setClearValues(cv));
     }
 
-    BackbufferStatus cmdEndBuiltInRenderPass(vk::CommandBuffer cb) {
+    void cmdEndBuiltInRenderPass(vk::CommandBuffer cb) {
         // can't begin render pass if the frame is not begun.
         RVI_REQUIRE(READY == _frameStatus);
 
@@ -3117,7 +3173,9 @@ public:
 
         _renderPass->cmdEnd(cb);
 
-        return DESIRED_PRESENT_STATUS;
+        // The render pass's finalLayout transitions the backbuffer to DESIRED_PRESENT_STATUS implicitly.
+        auto & bb = *currentFrame().backbuffer;
+        bb.image->setState(DESIRED_PRESENT_STATUS, Image::FULL_RANGE);
     }
 
     Frame beginFrame() {
@@ -3176,20 +3234,25 @@ public:
         auto & frame = currentFrame();
         auto & bb    = (BackbufferImpl &) *frame.backbuffer;
 
+        // Derive the current image state from the image's own tracking.
+        const auto * colorPlane = bb.image->getState().get(0, 0, vk::ImageAspectFlagBits::eColor);
+        auto         curStatus  = colorPlane ? *colorPlane : Image::State::PlaneState::UNDEFINED();
+
         // Transition the backbuffer image to present source layout.
         auto cb = _graphicsQueue->begin("frame end");
-        if (pp.backbufferStatus.layout != DESIRED_PRESENT_STATUS.layout) {
+        if (curStatus.layout != DESIRED_PRESENT_STATUS.layout) {
             Barrier()
-                .i(bb.image->handle(), pp.backbufferStatus.access, DESIRED_PRESENT_STATUS.access, pp.backbufferStatus.layout, DESIRED_PRESENT_STATUS.layout,
+                .i(bb.image->handle(), curStatus.access, DESIRED_PRESENT_STATUS.access, curStatus.layout, DESIRED_PRESENT_STATUS.layout,
                    vk::ImageAspectFlagBits::eColor)
-                .s(pp.backbufferStatus.stages, DESIRED_PRESENT_STATUS.stages)
+                .s(curStatus.stages, DESIRED_PRESENT_STATUS.stages)
                 .cmdWrite(cb);
         }
+        // Keep the image's tracked state in sync with the GPU layout after the transition.
+        bb.image->setState(DESIRED_PRESENT_STATUS, Image::FULL_RANGE);
         frame.frameEndSubmission = _graphicsQueue->submit({cb, {}, pp.renderFinished, {bb.frameEndSemaphore}});
 
         PresentResult pr;
-        pr.backbufferStatus = DESIRED_PRESENT_STATUS;
-        pr.status           = PresentResult::SUCCESS;
+        pr.status = PresentResult::SUCCESS;
 
         // present current frame
         if (_handle) {
@@ -3235,8 +3298,7 @@ private:
         uint32_t                   imageIndex {};
         CommandQueue::SubmissionID frameEndSubmission {};
 
-        // Back buffer is always in the desired present status when it is acquired.
-        FrameImpl() { backbufferStatus = DESIRED_PRESENT_STATUS; }
+        FrameImpl() = default;
 
         void waitForFrameEnd() {
             if (frameEndSubmission) {
@@ -3265,8 +3327,8 @@ private:
     std::vector<BackbufferImpl> _backbuffers;
     Ref<Image>                  _depthBuffer;
 
-    inline static constexpr BackbufferStatus DESIRED_PRESENT_STATUS = {vk::ImageLayout::ePresentSrcKHR, vk::AccessFlagBits::eMemoryRead,
-                                                                       vk::PipelineStageFlagBits::eBottomOfPipe};
+    inline static constexpr Image::State::PlaneState DESIRED_PRESENT_STATUS = {vk::ImageLayout::ePresentSrcKHR, vk::AccessFlagBits::eMemoryRead,
+                                                                               vk::PipelineStageFlagBits::eBottomOfPipe};
 
 private:
     const FrameImpl & currentFrame() const { return _frames[_frameCounter % std::size(_frames)]; }
@@ -3555,6 +3617,8 @@ private:
                    vk::ImageAspectFlagBits::eColor)
                 .s(vk::PipelineStageFlagBits::eAllCommands, DESIRED_PRESENT_STATUS.stages)
                 .cmdWrite(c);
+            // Keep image state in sync with the GPU layout we just transitioned into.
+            bb.image->setState(DESIRED_PRESENT_STATUS, Image::FULL_RANGE);
         }
 
         // execute the command buffer to update image layout
@@ -3604,6 +3668,8 @@ private:
                    vk::ImageAspectFlagBits::eColor)
                 .s(vk::PipelineStageFlagBits::eAllCommands, DESIRED_PRESENT_STATUS.stages)
                 .cmdWrite(c);
+            // Keep image state in sync with the GPU layout we just transitioned into.
+            bb.image->setState(DESIRED_PRESENT_STATUS, Image::FULL_RANGE);
 
             // create back buffer view
             bb.view = bb.image->getView({vk::ImageViewType::e2D, _cp.backbufferFormat});
@@ -3634,7 +3700,7 @@ auto Swapchain::cp() const -> const ConstructParameters & { return _impl->cp(); 
 auto Swapchain::renderPass() const -> vk::RenderPass { return _impl->renderPass().handle(); }
 auto Swapchain::graphics() const -> CommandQueue & { return _impl->graphics(); }
 void Swapchain::cmdBeginBuiltInRenderPass(vk::CommandBuffer cb, const BeginRenderPassParameters & bp) { return _impl->cmdBeginBuiltInRenderPass(cb, bp); }
-auto Swapchain::cmdEndBuiltInRenderPass(vk::CommandBuffer cb) -> BackbufferStatus { return _impl->cmdEndBuiltInRenderPass(cb); }
+void Swapchain::cmdEndBuiltInRenderPass(vk::CommandBuffer cb) { _impl->cmdEndBuiltInRenderPass(cb); }
 auto Swapchain::beginFrame() -> Frame { return _impl->beginFrame(); }
 auto Swapchain::present(const PresentParameters & pp) -> PresentResult { return _impl->present(pp); }
 

--- a/inc/rapid-vulkan/rapid-vulkan.cpp
+++ b/inc/rapid-vulkan/rapid-vulkan.cpp
@@ -4142,7 +4142,6 @@ Device::Device(const ConstructParameters & cp): _cp(cp) {
 //
 Device::~Device() {
     waitIdle();
-    for (auto q : _queues) delete q;
     _queues.clear();
 #if RAPID_VULKAN_ENABLE_VMA
     if (_gi.vmaAllocator) vmaDestroyAllocator(_gi.vmaAllocator), _gi.vmaAllocator = nullptr;

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -2263,6 +2263,11 @@ public:
 
     struct SubmitParameters {
         /// @brief The command buffers to submit. The command buffers must be allocated out of this queue class.
+        /// May be empty when the submission only carries semaphore operations — for example, a
+        /// timeline-to-binary bridge that waits on a timeline point and signals a binary semaphore
+        /// so that vkQueuePresentKHR (which only accepts binary semaphores) can consume it.
+        /// A submission with no command buffers AND no semaphore operations is a no-op and will
+        /// be silently ignored (submit() returns an empty SubmissionID).
         vk::ArrayProxy<const CommandBuffer> commandBuffers {};
 
         /// The optional fence object to signal once the command buffers have completed execution.

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -235,9 +235,11 @@ SOFTWARE.
 #define RVI_LOGI(...) RAPID_VULKAN_LOG(RAPID_VULKAN_NAMESPACE::LogSeverity::INFO, "[RAPID-VULKAN] [INFO] ", RAPID_VULKAN_NAMESPACE::format(__VA_ARGS__).c_str())
 #define RVI_LOGV(...) \
     RAPID_VULKAN_LOG(RAPID_VULKAN_NAMESPACE::LogSeverity::VERBOSE, "[RAPID-VULKAN] [VERBOSE] ", RAPID_VULKAN_NAMESPACE::format(__VA_ARGS__).c_str())
+#define RVI_LOGB(...) \
+    RAPID_VULKAN_LOG(RAPID_VULKAN_NAMESPACE::LogSeverity::BABBLE, "[RAPID-VULKAN] [BABBLE] ", RAPID_VULKAN_NAMESPACE::format(__VA_ARGS__).c_str())
 #if RAPID_VULKAN_ENABLE_DEBUG_BUILD
 #define RVI_LOGD(...) \
-    RAPID_VULKAN_LOG(RAPID_VULKAN_NAMESPACE::LogSeverity::DEBUG, "[RAPID-VULKAN] [DEBUG] ", RAPID_VULKAN_NAMESPACE::format(__VA_ARGS__).c_str())
+    RAPID_VULKAN_LOG(RAPID_VULKAN_NAMESPACE::LogSeverity::VERBOSE, "[RAPID-VULKAN] [DEBUG] ", RAPID_VULKAN_NAMESPACE::format(__VA_ARGS__).c_str())
 #else
 #define RVI_LOGD(...) void(0)
 #endif
@@ -315,8 +317,8 @@ enum class LogSeverity {
     ERROR_  = 10,
     WARNING = 20,
     INFO    = 30,
-    DEBUG   = 40,
-    VERBOSE = 50,
+    VERBOSE = 40,
+    BABBLE  = 50,
 };
 
 // namespace rv_details {
@@ -1758,7 +1760,7 @@ public:
         uint32_t                                           subpass {};
         std::vector<vk::Format>                            dynamicRenderingColorFormats {}; ///< non-empty => use dynamic rendering (ignore pass)
         vk::Format                                         dynamicRenderingDepthFormat {vk::Format::eUndefined};
-        const Shader *                                     vs {}; ///< vertex shasder. can't be null.
+        const Shader *                                     vs {}; ///< vertex shader. can't be null.
         const Shader *                                     fs {}; ///< fragment shader. can be null.
         std::vector<vk::VertexInputAttributeDescription>   va {};
         std::vector<vk::VertexInputBindingDescription>     vb {};
@@ -1821,6 +1823,19 @@ public:
             desc.offset   = (uint32_t) offset;
             desc.format   = format;
             va.push_back(desc);
+            return *this;
+        }
+
+        /// @brief Set vertex attribute for a specific location. The location may be specified out of order.
+        /// The method will expand the vertex attribute array if necessary to accommodate the specified location. But this may leave some vertex attributes
+        /// in the middle uninitialized. It is caller's responsibility to ensure all vertex attributes are properly initialized before creating the pipeline.
+        ConstructParameters & setVertexAttribute(size_t location, size_t binding, size_t offset, vk::Format format) {
+            if (va.size() <= location) va.resize(location + 1);
+            auto & desc = va[location];
+            desc.binding  = (uint32_t) binding;
+            desc.location = (uint32_t) location;
+            desc.offset   = (uint32_t) offset;
+            desc.format   = format;
             return *this;
         }
 

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -459,7 +459,7 @@ inline void setVkHandleName(vk::Device device, T handle, const char * name) {
 // ---------------------------------------------------------------------------------------------------------------------
 /// Helper function to set Vulkan opaque handle's name (VK_EXT_debug_utils).
 template<typename T>
-inline void setVkHandleName(vk::Device device, T handle, std::string name) {
+inline void setVkHandleName(vk::Device device, T handle, const std::string & name) {
     setVkHandleName(device, handle, name.c_str());
 }
 
@@ -2478,8 +2478,8 @@ public:
     };
 
     struct PresentResult {
-        inline static constexpr int FAILED = -1;
-        inline static constexpr int SUCCESS = 0;
+        inline static constexpr int FAILED     = -1;
+        inline static constexpr int SUCCESS    = 0;
         inline static constexpr int SUBOPTIMAL = 1;
 
         /// The result status of the present() call.
@@ -2655,12 +2655,12 @@ public:
     vk::Device operator->() const { return _gi.device; }
 
 private:
-    ConstructParameters         _cp;
-    GlobalInfo                  _gi {};
-    std::vector<CommandQueue *> _queues; // one for each queue family
-    CommandQueue *              _graphics = nullptr;
-    CommandQueue *              _compute  = nullptr;
-    CommandQueue *              _transfer = nullptr;
+    ConstructParameters            _cp;
+    GlobalInfo                     _gi {};
+    std::vector<Ref<CommandQueue>> _queues; // one for each queue family
+    CommandQueue *                 _graphics = nullptr;
+    CommandQueue *                 _compute  = nullptr;
+    CommandQueue *                 _transfer = nullptr;
 };
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -2478,14 +2478,12 @@ public:
     };
 
     struct PresentResult {
-        enum Status {
-            FAILED     = -1, ///< Present failed. The back buffer image state is undefined; consider recreating the swapchain.
-            SUCCESS    = 0,  ///< Present succeeded. The back buffer image is in VK_IMAGE_LAYOUT_PRESENT_SRC_KHR.
-            SUBOPTIMAL = 1,  ///< Present succeeded, but the swapchain is suboptimal.
-        };
+        inline static constexpr int FAILED = -1;
+        inline static constexpr int SUCCESS = 0;
+        inline static constexpr int SUBOPTIMAL = 1;
 
         /// The result status of the present() call.
-        Status status = FAILED;
+        int status = FAILED;
 
         operator bool() const { return status != FAILED; }
     };

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -352,6 +352,20 @@ struct GlobalInfo {
     vk::Device                      device              = nullptr;
     uint32_t                        graphicsQueueFamily = VK_QUEUE_FAMILY_IGNORED;
 
+    union {
+        uint32_t features = 0;
+
+        struct {
+            /// True when vkQueueSubmit2 is available — either Vulkan 1.3 core or VK_KHR_synchronization2
+            /// extension enabled. The Device constructor sets this; callers must not write to it.
+            bool synchronization2 : 1;
+
+            /// True when timeline semaphores are available — either Vulkan 1.2 core or
+            /// VK_KHR_timeline_semaphore extension enabled. The Device constructor sets this.
+            bool timelineSemaphore : 1;
+        };
+    };
+
 #if RAPID_VULKAN_ENABLE_VMA
     VmaAllocator vmaAllocator = nullptr;
 #endif
@@ -2257,18 +2271,41 @@ public:
         uint32_t           index  = 0; ///< queue index within family
     };
 
+    struct SyncPoint {
+        /// The handle of the semaphore. Can be either timeline or binary semaphore.
+        vk::Semaphore semaphore = {};
+
+        // the monolithic increasing counter of the timeline.
+        uint64_t progress = {};
+
+        /// The state flag of the sync point. Ignored when the sync point is used in signal list.
+        vk::PipelineStageFlags stages = vk::PipelineStageFlagBits::eAllCommands;
+
+        bool empty() const { return !semaphore; }
+
+        operator bool() const { return !!semaphore; }
+    };
+
     struct SubmitParameters {
         /// @brief The command buffers to submit. The command buffers must be allocated out of this queue class.
         vk::ArrayProxy<const CommandBuffer> commandBuffers {};
 
-        /// The (optional) fence object to signal once the command buffers have completed execution.
+        /// The optional fence object to signal once the command buffers have completed execution.
         vk::Fence signalFence = {};
 
-        /// @brief List of semaphores to wait for before executing the command buffers.
-        vk::ArrayProxy<const vk::Semaphore> waitSemaphores {};
+        /// @brief Optional list of binary sync points to wait for before executing the command buffers.
+        vk::ArrayProxy<const SyncPoint> waitBinaries {};
 
-        /// @brief List of semaphores to signal once the command buffers have completed execution.
-        vk::ArrayProxy<const vk::Semaphore> signalSemaphores {};
+        /// @brief Optional list of timeline semaphores to wait for. Requires timeline feature enabled.
+        vk::ArrayProxy<const SyncPoint> waitPoints {};
+
+        /// @brief Optional list of binary semaphores to signal once the command buffers have completed execution.
+        /// For Vulkan 1.1 and 1.2, signal state flags are not supported and will be ignored.
+        vk::ArrayProxy<const SyncPoint> signalBinaries {};
+
+        /// @brief Optional list of timeline points to signal. Requires timeline feature enabled.
+        /// For Vulkan 1.1 and 1.2, signal state flags are not supported and will be ignored.
+        vk::ArrayProxy<const SyncPoint> signalPoints {};
     };
 
     /// @brief unique identifier of a GPU submission
@@ -2464,7 +2501,6 @@ public:
 
     /// @brief Specify parameters to call present().
     struct PresentParameters {
-
         /// @brief Optional list of semaphores that present() call uses to ensure presenting happens after all rendering of the frame is done.
         /// !!! IMPORTANT !!! : If not empty, caller MUST ensure that all semaphores in the list are signaled by the end of the frame rendering.
         /// Failing to do so will cause present() to wait forever. On the other hand, signaling these

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -26,7 +26,7 @@ SOFTWARE.
 #define RAPID_VULKAN_H_
 
 /// A monotonically increasing number that uniquely identifies the revision of the header.
-#define RAPID_VULKAN_HEADER_REVISION 30
+#define RAPID_VULKAN_HEADER_REVISION 31
 
 /// \def RAPID_VULKAN_NAMESPACE
 /// Define the namespace of rapid-vulkan library.
@@ -1306,10 +1306,13 @@ public:
         Desc               desc {};
     };
 
+    inline static constexpr vk::ImageSubresourceRange FULL_RANGE = {vk::FlagTraits<vk::ImageAspectFlagBits>::allFlags, 0, VK_REMAINING_MIP_LEVELS, 0,
+                                                                    VK_REMAINING_ARRAY_LAYERS};
+
     struct GetViewParameters {
         vk::ImageViewType         type   = (vk::ImageViewType) -1; ///< set to -1 to use the default view type.
         vk::Format                format = vk::Format::eUndefined; ///< set to eUndefined to use image's format.
-        vk::ImageSubresourceRange range  = {{}, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS};
+        vk::ImageSubresourceRange range  = FULL_RANGE;
 
         GetViewParameters & setType(vk::ImageViewType t) {
             type = t;
@@ -1360,9 +1363,8 @@ public:
     };
 
     struct ReadContentParameters {
-        uint32_t        queueFamily   = 0;
-        uint32_t        queueIndex    = 0;
-        vk::ImageLayout currentLayout = vk::ImageLayout::eTransferSrcOptimal;
+        uint32_t queueFamily = 0;
+        uint32_t queueIndex  = 0;
 
         ReadContentParameters & setQueue(uint32_t family, uint32_t index) {
             queueFamily = family;
@@ -1371,11 +1373,6 @@ public:
         }
 
         ReadContentParameters & setQueue(const CommandQueue &);
-
-        ReadContentParameters & setCurrentLayout(vk::ImageLayout l) {
-            currentLayout = l;
-            return *this;
-        }
     };
 
     struct SubresourceContent {
@@ -1399,11 +1396,66 @@ public:
         operator bool() const { return format != vk::Format::eUndefined && !storage.empty() && !subresources.empty(); }
     };
 
-    /// @brief A utility function to determine image aspect flags from a format.
-    /// @param format The pixel format of the image.
-    /// @param hint   The hint of the aspect flags. The function will try to use this hinted aspect flag, as long as it is compatible with the format.
-    ///               Set to vk::ImageAspectFlagBits::eNone to let the function determine the aspect flags.
-    static vk::ImageAspectFlags determineImageAspect(vk::Format format, vk::ImageAspectFlags hint = vk::ImageAspectFlagBits::eNoneKHR);
+    /// Tracks per-subresource Vulkan image state (layout, access flags, pipeline stage).
+    /// Each subresource slot holds one PlaneState per aspect plane the image's format has.
+    /// The plane set is fixed at image construction time and never grows or shrinks.
+    struct State {
+        /// State of a single aspect plane of a single subresource.
+        struct PlaneState {
+            vk::ImageLayout        layout = vk::ImageLayout::eUndefined;
+            vk::AccessFlags        access = vk::AccessFlagBits::eNone;
+            vk::PipelineStageFlags stages = vk::PipelineStageFlagBits::eBottomOfPipe;
+            const char *           usage  = "<unspecified>";
+
+            bool operator==(const PlaneState & o) const { return layout == o.layout && access == o.access && stages == o.stages; }
+            bool operator!=(const PlaneState & o) const { return !(*this == o); }
+
+            bool isWrite() const {
+                // clang-format off
+                return (access & (vk::AccessFlagBits::eShaderWrite |
+                                  vk::AccessFlagBits::eColorAttachmentWrite |
+                                  vk::AccessFlagBits::eDepthStencilAttachmentWrite |
+                                  vk::AccessFlagBits::eTransferWrite |
+                                  vk::AccessFlagBits::eHostWrite |
+                                  vk::AccessFlagBits::eMemoryWrite)) != vk::AccessFlags{};
+                // clang-format on
+            }
+
+            static constexpr PlaneState UNDEFINED() {
+                return {vk::ImageLayout::eUndefined, vk::AccessFlagBits::eNone, vk::PipelineStageFlagBits::eBottomOfPipe};
+            }
+            static constexpr PlaneState TRANSFER_SRC() {
+                return {vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits::eTransferRead, vk::PipelineStageFlagBits::eTransfer};
+            }
+            static constexpr PlaneState TRANSFER_DST() {
+                return {vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits::eTransferWrite, vk::PipelineStageFlagBits::eTransfer};
+            }
+        };
+
+        struct AspectHash {
+            size_t operator()(vk::ImageAspectFlagBits a) const { return std::hash<uint32_t> {}(static_cast<uint32_t>(a)); }
+        };
+        struct SubresourceState {
+            std::unordered_map<vk::ImageAspectFlagBits, PlaneState, AspectHash> planes;
+        };
+
+        /// Returns per-plane state for (mip, arrayLayer, aspect), or nullptr if out of range or not a
+        /// valid plane for this image's format.
+        const PlaneState * get(uint32_t mip, uint32_t arrayLayer, vk::ImageAspectFlagBits aspect) const {
+            if (mip >= numMips || arrayLayer >= numLayers) RVI_UNLIKELY return nullptr;
+            const auto & sr = subresources[subresourceIndex(mip, arrayLayer)];
+            auto         it = sr.planes.find(aspect);
+            if (it == sr.planes.end()) RVI_UNLIKELY return nullptr;
+            return &it->second;
+        }
+
+        size_t subresourceIndex(uint32_t mip, uint32_t arrayLayer) const { return mip * numLayers + arrayLayer; }
+
+        vk::ImageAspectFlags          validAspects = {};
+        uint32_t                      numMips      = 0;
+        uint32_t                      numLayers    = 0;
+        std::vector<SubresourceState> subresources; // size = numMips * numLayers. Use subresourceIndex() to index into it.
+    };
 
     /// @brief Construct an image from scratch (will create a new vk::Image handle)
     Image(const ConstructParameters &);
@@ -1425,9 +1477,17 @@ public:
     bool setContent(const SetContentParameters &);
 
     /// @brief Synchronously read content of the whole image.
-    /// This method, if succeeded, will transfer the entire image into vk::ImageLayout::eTransferSrcOptimal layout.
-    /// If failed, returns empty content with undefined format.
-    Content readContent(const ReadContentParameters &) const;
+    /// Transitions every subresource to eTransferSrcOptimal and updates internal state on success.
+    /// Returns empty content with undefined format on failure.
+    Content readContent(const ReadContentParameters &);
+
+    /// @brief Returns the current per-subresource image state tracked internally.
+    const State & getState() const;
+
+    /// @brief Updates the state for all subresources in \p range.
+    /// The aspectMask in \p range is intersected with the image's valid planes; unknown bits are ignored.
+    /// The default range covers all aspects, all mips, and all array layers of the entire image.
+    void setState(const State::PlaneState & newState, const vk::ImageSubresourceRange & range = FULL_RANGE);
 
     vk::Image handle() const { return desc().handle; }
 
@@ -2345,13 +2405,6 @@ public:
             return *this;
         }
     };
-    /// @brief Specify the current status of the back buffer image.
-    struct BackbufferStatus {
-        vk::ImageLayout        layout {};
-        vk::AccessFlags        access {};
-        vk::PipelineStageFlags stages {};
-    };
-
     struct Backbuffer {
         Image *         image {}; // this is never null for a valid backbuffer.
         vk::ImageView   view {};
@@ -2363,9 +2416,6 @@ public:
         /// @brief Pointer to the backbuffer of the frame.
         /// The pointer value will be invalidated after each present.
         const Backbuffer * backbuffer = nullptr;
-
-        /// Status of the back buffer image at the beginning of the frame.
-        BackbufferStatus backbufferStatus {};
 
         /// @brief The semaphore that will be signaled when the last present of the current backbuffer image is done.
         /// The first rendering submission for current frame should wait for this semaphore.
@@ -2385,12 +2435,6 @@ public:
         /// @brief Specify the clear value for depth and stencil buffer.
         vk::ClearDepthStencilValue clearDepth = vk::ClearDepthStencilValue(1.0f, 0);
 
-        /// @brief Specify the current status of the back buffer image.
-        /// This is for the cmdBeginRenderPass() method insert proper barriers to transition the image to the desired layout for the render pass.
-        /// If the back buffer is already in vk::ImageLayout::eColorAttachmentOptimal layout, then no barrier will be inserted.
-        /// When built-in render pass ends, the back buffer image will be automatically transitioned into status suitable for present().
-        // BackbufferStatus backbufferStatus = {vk::ImageLayout::ePresentSrcKHR, vk::AccessFlagBits::eMemoryRead, vk::PipelineStageFlagBits::eBottomOfPipe};
-
         BeginRenderPassParameters & setClearColorF(vk::ArrayProxy<const float> color) {
             clearColor.setFloat32({color.size() > 0 ? color.data()[0] : 0.f, color.size() > 1 ? color.data()[1] : 0.f, color.size() > 2 ? color.data()[2] : 0.f,
                                    color.size() > 3 ? color.data()[3] : 1.f});
@@ -2406,22 +2450,11 @@ public:
     /// @brief Specify parameters to call present().
     struct PresentParameters {
 
-        /// @brief Specify the current status of the back buffer image when calling present().
-        /// The present() function will insert proper barrier to transit the current back buffer image into VK_IMAGE_LAYOUT_PRESENT_SRC_KHR layouy.
-        /// If the back buffer image is already in VK_IMAGE_LAYOUT_PRESENT_SRC_KHR layout, then no barrier will be inserted.
-        BackbufferStatus backbufferStatus;
-
         /// @brief Optional list of semaphores that present() call uses to ensure presenting happens after all rendering of the frame is done.
-        /// !!! IMPORTANT !!! : If not empty, caller MUST ensure that all semaphores in the list are signaled by th end of the frame rendering.
+        /// !!! IMPORTANT !!! : If not empty, caller MUST ensure that all semaphores in the list are signaled by the end of the frame rendering.
         /// Failing to do so will cause present() to wait forever. On the other hand, signaling these
         /// semaphores too early could cause present() showing partially rendered frame.
         vk::ArrayProxy<const vk::Semaphore> renderFinished = {};
-
-        PresentParameters(vk::ImageLayout backbufferLayuout, vk::AccessFlags backbufferAccessFlags) {
-            backbufferStatus = {backbufferLayuout, backbufferAccessFlags, vk::PipelineStageFlagBits::eBottomOfPipe};
-        }
-
-        PresentParameters(const BackbufferStatus & backbufferStatus_): backbufferStatus(backbufferStatus_) {}
 
         PresentParameters & setRenderFinished(vk::ArrayProxy<const vk::Semaphore> renderFinished_) {
             renderFinished = renderFinished_;
@@ -2431,20 +2464,13 @@ public:
 
     struct PresentResult {
         enum Status {
-            FAILED     = -1, ///< Present failed. The back buffer image is in undefined state. Consider delete and recreate the swapchain.
-            SUCCESS    = 0,  ///< Present successfully. The back buffer image is now in the layout specified by the backbufferStatus field.
-            SUBOPTIMAL = 1,  ///< Present successfully, but the swapchain is in suboptimal state. The back buffer image is now in the layout specified by the
-                             ///< backbufferStatus field.
+            FAILED     = -1, ///< Present failed. The back buffer image state is undefined; consider recreating the swapchain.
+            SUCCESS    = 0,  ///< Present succeeded. The back buffer image is in VK_IMAGE_LAYOUT_PRESENT_SRC_KHR.
+            SUBOPTIMAL = 1,  ///< Present succeeded, but the swapchain is suboptimal.
         };
 
-        /// The result status of the present() call. If FAILED, the rest of the structure is undefined.
+        /// The result status of the present() call.
         Status status = FAILED;
-
-        /// The actual status of the back buffer image after present() call.
-        /// Note that the status specified in the PresentParameters may not be the same as this value,
-        /// since present() will insert proper barriers to transition the image into a layout suitable for presentation.
-        /// Undefined if the present() call failed.
-        BackbufferStatus backbufferStatus;
 
         operator bool() const { return status != FAILED; }
     };
@@ -2484,10 +2510,10 @@ public:
     /// @brief Begin a new built-in render pass. Can only be called between beginFrame() and present().
     void cmdBeginBuiltInRenderPass(vk::CommandBuffer, const BeginRenderPassParameters &);
 
-    /// @brief End the built-in render pass. Returns the
-    /// After built-in render pass ends, the back buffer image will be automatically transitioned into status suitable for present(). You can check the
-    /// actual value of the status via currentFrame().backbuffer->status.
-    BackbufferStatus cmdEndBuiltInRenderPass(vk::CommandBuffer);
+    /// @brief End the built-in render pass.
+    /// After the render pass ends, the back buffer image is automatically transitioned to VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+    /// and the image's tracked state is updated accordingly.
+    void cmdEndBuiltInRenderPass(vk::CommandBuffer);
 
 private:
     class Impl;

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -352,20 +352,6 @@ struct GlobalInfo {
     vk::Device                      device              = nullptr;
     uint32_t                        graphicsQueueFamily = VK_QUEUE_FAMILY_IGNORED;
 
-    union {
-        uint32_t features = 0;
-
-        struct {
-            /// True when vkQueueSubmit2 is available — either Vulkan 1.3 core or VK_KHR_synchronization2
-            /// extension enabled. The Device constructor sets this; callers must not write to it.
-            bool synchronization2 : 1;
-
-            /// True when timeline semaphores are available — either Vulkan 1.2 core or
-            /// VK_KHR_timeline_semaphore extension enabled. The Device constructor sets this.
-            bool timelineSemaphore : 1;
-        };
-    };
-
 #if RAPID_VULKAN_ENABLE_VMA
     VmaAllocator vmaAllocator = nullptr;
 #endif
@@ -2333,11 +2319,13 @@ public:
     /// @brief Begin recording a command buffer.
     CommandBuffer begin(const char * name, vk::CommandBufferLevel level = vk::CommandBufferLevel::ePrimary);
 
-    /// @brief Submit command buffers to the queue for asynchronous processing.
-    /// After this call, all command buffer pointers are inaccessible. The caller should not use them anymore.
-    /// @return A submission ID that later to check/wait for the completion of the submission. Return an empty
-    /// handle on failure.
-    SubmissionID submit(const SubmitParameters &);
+    /// Submit using VkSubmitInfo (Vulkan 1.0+). Supports timeline semaphores via the
+    /// VkTimelineSemaphoreSubmitInfo pNext chain when waitPoints/signalPoints are non-empty.
+    SubmissionID submit1(const SubmitParameters &);
+
+    /// Submit using VkSubmitInfo2 (requires synchronization2 — Vulkan 1.3 core or
+    /// VK_KHR_synchronization2 extension). Caller must ensure the feature is enabled.
+    SubmissionID submit2(const SubmitParameters &);
 
     /// @brief Drop command buffers. Discard all contents of them.
     /// After this call, the command buffer pointers are inaccessible. The caller should not use them anymore.

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -2176,17 +2176,6 @@ class CommandBuffer {
 public:
     class Impl;
 
-    struct SubmitParameters {
-        /// The (optional) fence object to signal once the command buffers have completed execution.
-        vk::Fence signalFence = {};
-
-        /// @brief List of semaphores to wait for before executing the command buffers.
-        vk::ArrayProxy<const vk::Semaphore> waitSemaphores {};
-
-        /// @brief List of semaphores to signal once the command buffers have completed execution.
-        vk::ArrayProxy<const vk::Semaphore> signalSemaphores {};
-    };
-
     CommandBuffer(Impl * impl = nullptr): _impl(impl) {}
     CommandBuffer(const CommandBuffer & o): _impl(o._impl) {}
     ~CommandBuffer() = default;

--- a/inc/rapid-vulkan/rapid-vulkan.h
+++ b/inc/rapid-vulkan/rapid-vulkan.h
@@ -1831,7 +1831,7 @@ public:
         /// in the middle uninitialized. It is caller's responsibility to ensure all vertex attributes are properly initialized before creating the pipeline.
         ConstructParameters & setVertexAttribute(size_t location, size_t binding, size_t offset, vk::Format format) {
             if (va.size() <= location) va.resize(location + 1);
-            auto & desc = va[location];
+            auto & desc   = va[location];
             desc.binding  = (uint32_t) binding;
             desc.location = (uint32_t) location;
             desc.offset   = (uint32_t) offset;


### PR DESCRIPTION
## Summary
This change updates the Vulkan queue submission path to support newer submit workflows, including timeline semaphore use, while preserving caller control over which submit API is used. It also tightens command buffer resource lifetime tracking and image subresource layout state so dependent Vulkan objects remain valid across recorded work.

The related samples and tests were adjusted to cover the updated behavior.

## Tests
Not run in this session.